### PR TITLE
feat(poster): scored personalities, hover legend, perf pan/zoom, richer maps

### DIFF
--- a/.agents/skills/codebase-poster/SKILL.md
+++ b/.agents/skills/codebase-poster/SKILL.md
@@ -69,8 +69,12 @@ small JSON object, then upload it to foglamp to get a **shareable link**
 ## Rules — these keep every poster consistent, do not break them
 
 - **Caps:** `topModels` ≤ 3, `topTools` ≤ 5, `topIntegrations` ≤ 5,
-  `graph.nodes` ≤ 18, `graph.edges` ≤ 32. **Prioritize** — pick the most
-  important, most-used items. Do not dump everything.
+  `graph.nodes` ≤ 24, `graph.edges` ≤ 48. Aim for 14–22 nodes on a substantial
+  codebase — the map should feel rich, not sparse.
+- Give every distinct agent its **own node** when there are ≤ 10 agents; only
+  group agents when they're numerous and near-identical (then say so in `sub`).
+  Chain agents with agent→agent edges when one feeds the next — pipelines read
+  better than hub-and-spoke.
 - **Node labels ≤ 28 chars**, `sub` ≤ 40, edge labels ≤ 24. Keep them tight.
 - **`kind`** is one of: `entry` (trigger/route/page/CLI), `cron` (scheduled job),
   `agent`, `model`, `tool`, `store` (DB/cache/index), `external` (3rd-party API).

--- a/apps/web/src/components/poster/brand.tsx
+++ b/apps/web/src/components/poster/brand.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { cn } from "@foglamp/ui/lib/utils";
+import { IconSparklesFilled } from "@tabler/icons-react";
 import { useState, type ReactNode } from "react";
 
-import { faviconUrl } from "./favicon";
+import {
+  ClaudeLogo,
+  GeminiLogo,
+  OpenAILogo,
+} from "@/components/brand-logos";
+import { faviconUrl, modelDomain } from "./favicon";
 
 /** Foglamp brand mark — three overlapping circles (lead → blue → orange). */
 export function BrandMark({ className }: { className?: string }) {
@@ -40,6 +46,32 @@ export function Favicon({
       alt=""
       className={cn("corner-squircle object-contain", className)}
       onError={() => setFailed(true)}
+    />
+  );
+}
+
+/**
+ * A model's mark. Known models get the crisp local brand SVG (favicons ship on
+ * white tiles — Claude's starburst-in-a-box); anything else falls back to the
+ * favicon proxy, then a sparkle glyph.
+ */
+export function ModelIcon({
+  label,
+  domain,
+  className,
+}: {
+  label: string;
+  domain?: string;
+  className?: string;
+}) {
+  if (/claude|anthropic/i.test(label)) return <ClaudeLogo className={className} />;
+  if (/gemini/i.test(label)) return <GeminiLogo className={className} />;
+  if (/gpt|openai|^o\d/i.test(label)) return <OpenAILogo className={className} />;
+  return (
+    <Favicon
+      domain={modelDomain(label, domain)}
+      className={className}
+      fallback={<IconSparklesFilled className={className} />}
     />
   );
 }

--- a/apps/web/src/components/poster/flow-map.tsx
+++ b/apps/web/src/components/poster/flow-map.tsx
@@ -3,10 +3,9 @@
 import type { NodeKind, PosterData } from "@foglamp/contracts/poster";
 import { cn } from "@foglamp/ui/lib/utils";
 import { motion } from "motion/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
-import { Favicon } from "./brand";
-import { modelDomain } from "./favicon";
+import { Favicon, ModelIcon } from "./brand";
 import { foldGraph, type FoldedNode } from "./fold-graph";
 import { KIND_STYLES } from "./kinds";
 import {
@@ -37,10 +36,10 @@ function nodeHeight(n: FoldedNode): number {
 
 export function FlowMap({
   graph,
-  focusKind,
+  focusKinds,
 }: {
   graph: PosterData["graph"];
-  focusKind: NodeKind | null;
+  focusKinds: NodeKind[] | null;
 }) {
   const folded = useMemo(() => foldGraph(graph), [graph]);
 
@@ -131,18 +130,18 @@ export function FlowMap({
     return { nodes, edges };
   }, [traceRoot, folded.edges]);
 
-  // Legend focus: a node matches if it IS the kind or embeds it.
+  // Legend focus (hover): a node matches if it IS one of the kinds or embeds one.
   const kindActive = useMemo(() => {
-    if (!focusKind) return null;
+    if (!focusKinds || focusKinds.length === 0) return null;
+    const kinds = new Set(focusKinds);
     return new Set(
       folded.nodes
         .filter(
-          (n) =>
-            n.kind === focusKind || n.embeds.some((em) => em.kind === focusKind)
+          (n) => kinds.has(n.kind) || n.embeds.some((em) => kinds.has(em.kind))
         )
         .map((n) => n.id)
     );
-  }, [focusKind, folded.nodes]);
+  }, [focusKinds, folded.nodes]);
 
   const nodeActive = (id: string) =>
     (!related || related.has(id)) &&
@@ -153,8 +152,15 @@ export function FlowMap({
     (!kindActive || kindActive.has(e.from) || kindActive.has(e.to)) &&
     (!trace || trace.edges.has(i));
 
+  // ─── Pan/zoom, imperatively ─────────────────────────────────────────────────
+  // The transform lives in a ref and is written straight to the DOM — running
+  // it through React state re-rendered the whole graph on every pointermove /
+  // wheel frame, which is what made big maps feel laggy.
   const viewportRef = useRef<HTMLDivElement>(null);
-  const [t, setT] = useState<Transform>({ x: 0, y: 0, k: 1 });
+  const graphRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const tRef = useRef<Transform>({ x: 0, y: 0, k: 1 });
+  const tracedPosRef = useRef<{ x: number; y: number } | null>(null);
   const fitted = useRef(false);
   const drag = useRef<{
     px: number;
@@ -164,8 +170,22 @@ export function FlowMap({
     moved: boolean;
   } | null>(null);
 
+  function applyTransform() {
+    const t = tRef.current;
+    const g = graphRef.current;
+    if (g) g.style.transform = `translate(${t.x}px, ${t.y}px) scale(${t.k})`;
+    const pop = popoverRef.current;
+    const pos = tracedPosRef.current;
+    if (pop && pos) {
+      pop.style.left = `${t.x + pos.x * t.k}px`;
+      pop.style.top = `${t.y + pos.y * t.k}px`;
+    }
+  }
+
   // Fit the graph into the visible area (right of the floating sidebar) once.
-  useEffect(() => {
+  // Capped at 1 — upscaling small graphs blows the cards past native size
+  // (fat borders/shadows) and reads as broken layout.
+  useLayoutEffect(() => {
     const el = viewportRef.current;
     if (!el || fitted.current || !layout || layout.width === 0) return;
     const padL = 432; // clear the sidebar
@@ -173,17 +193,28 @@ export function FlowMap({
     const padY = 56;
     const availW = Math.max(200, el.clientWidth - padL - padR);
     const availH = Math.max(200, el.clientHeight - padY * 2);
-    const k = clamp(
-      Math.min(availW / layout.width, availH / layout.height),
-      0.2,
-      1.4
-    );
-    setT({
-      x: padL + (availW - layout.width * k) / 2,
-      y: padY + (availH - layout.height * k) / 2,
-      k,
-    });
+    const kFit = Math.min(availW / layout.width, availH / layout.height);
+    if (kFit >= 0.45) {
+      // The whole graph fits at a readable size — center it.
+      const k = clamp(kFit, 0.3, 1);
+      tRef.current = {
+        x: padL + (availW - layout.width * k) / 2,
+        y: padY + (availH - layout.height * k) / 2,
+        k,
+      };
+    } else {
+      // Deep pipeline: fitting everything would be unreadably small. Fit the
+      // height at a readable scale and open on the START of the flow — the
+      // user pans right through the story.
+      const k = clamp((availH / layout.height) * 0.9, 0.5, 0.8);
+      tRef.current = {
+        x: padL + 16,
+        y: padY + (availH - layout.height * k) / 2,
+        k,
+      };
+    }
     fitted.current = true;
+    applyTransform();
   }, [layout]);
 
   // Wheel zoom (and trackpad pinch, which arrives as ctrlKey+wheel). Native
@@ -196,16 +227,16 @@ export function FlowMap({
       const rect = el.getBoundingClientRect();
       const cx = e.clientX - rect.left;
       const cy = e.clientY - rect.top;
-      setT((prev) => {
-        const factor = Math.exp(-e.deltaY * (e.ctrlKey ? 0.012 : 0.0018));
-        const k = clamp(prev.k * factor, 0.2, 3);
-        const ratio = k / prev.k;
-        return {
-          k,
-          x: cx - (cx - prev.x) * ratio,
-          y: cy - (cy - prev.y) * ratio,
-        };
-      });
+      const prev = tRef.current;
+      const factor = Math.exp(-e.deltaY * (e.ctrlKey ? 0.012 : 0.0018));
+      const k = clamp(prev.k * factor, 0.2, 3);
+      const ratio = k / prev.k;
+      tRef.current = {
+        k,
+        x: cx - (cx - prev.x) * ratio,
+        y: cy - (cy - prev.y) * ratio,
+      };
+      applyTransform();
     };
     el.addEventListener("wheel", onWheel, { passive: false });
     return () => el.removeEventListener("wheel", onWheel);
@@ -216,8 +247,8 @@ export function FlowMap({
     drag.current = {
       px: e.clientX,
       py: e.clientY,
-      tx: t.x,
-      ty: t.y,
+      tx: tRef.current.x,
+      ty: tRef.current.y,
       moved: false,
     };
   }
@@ -225,19 +256,30 @@ export function FlowMap({
     const d = drag.current;
     if (!d) return;
     if (Math.hypot(e.clientX - d.px, e.clientY - d.py) > 4) d.moved = true;
-    setT((prev) => ({
-      ...prev,
+    tRef.current = {
+      ...tRef.current,
       x: d.tx + (e.clientX - d.px),
       y: d.ty + (e.clientY - d.py),
-    }));
+    };
+    applyTransform();
   }
   function endDrag() {
     // A stationary pointer-up on the canvas clears the trace.
-    if (drag.current && !drag.current.moved) setTraceRoot(null);
+    if (drag.current && !drag.current.moved) {
+      setTraceRoot(null);
+      tracedPosRef.current = null;
+    }
     drag.current = null;
   }
 
   const tracedNode = traceRoot ? nodeById.get(traceRoot) : null;
+  if (tracedNode) {
+    tracedPosRef.current = {
+      x: tracedNode.x,
+      y: tracedNode.y + tracedNode.height + 10,
+    };
+  }
+  const tNow = tRef.current;
 
   return (
     <section className="absolute inset-0 z-10">
@@ -253,11 +295,12 @@ export function FlowMap({
       >
         {layout ? (
           <div
-            className="absolute left-0 top-0 origin-top-left"
+            ref={graphRef}
+            className="absolute left-0 top-0 origin-top-left will-change-transform"
             style={{
               width: layout.width,
               height: layout.height,
-              transform: `translate(${t.x}px, ${t.y}px) scale(${t.k})`,
+              transform: `translate(${tNow.x}px, ${tNow.y}px) scale(${tNow.k})`,
             }}
           >
             {/* swimlanes — one faint band per alternating layer */}
@@ -265,7 +308,7 @@ export function FlowMap({
               i % 2 === 1 ? (
                 <div
                   key={i}
-                  className="absolute rounded-2xl dark:bg-neutral-900/70 bg-card/70"
+                  className="absolute rounded-2xl bg-foreground/[0.02]"
                   style={{
                     left: lane.min - 18,
                     width: lane.max - lane.min + 36,
@@ -304,25 +347,19 @@ export function FlowMap({
                       animate={{ pathLength: 1, opacity: 1 }}
                       transition={{ duration: 0.6, delay, ease: "easeOut" }}
                     />
-                    {/* traveling pulse, tinted by the source node's kind */}
-                    <motion.path
+                    {/* traveling pulse — pure CSS so N edges don't each run a
+                        JS animation loop; sparse dash so it doesn't pollute */}
+                    <path
                       d={d}
                       fill="none"
                       stroke={KIND_STYLES[sourceKind].hex}
                       strokeWidth={1.6}
                       strokeLinecap="round"
-                      strokeDasharray="5 72"
-                      strokeOpacity={0.7}
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1, strokeDashoffset: [0, -77] }}
-                      transition={{
-                        opacity: { delay: delay + 0.7, duration: 0.4 },
-                        strokeDashoffset: {
-                          delay: delay + 0.7,
-                          duration: 2.4,
-                          repeat: Infinity,
-                          ease: "linear",
-                        },
+                      strokeDasharray="4 156"
+                      strokeOpacity={0.55}
+                      style={{
+                        opacity: 0,
+                        animation: `poster-fade 0.5s ease ${delay + 0.8}s forwards, poster-pulse 5.5s linear ${delay + 0.8}s infinite`,
                       }}
                     />
                     <motion.path
@@ -400,22 +437,31 @@ export function FlowMap({
                       dim && "opacity-25"
                     )}
                   >
-                    <div className="flex h-14 flex-none items-center gap-2.5 px-3">
+                    <div className="flex h-14 flex-none items-center gap-2.5 px-4">
                       <span
                         className={cn(
-                          "flex size-7 flex-none items-center justify-center rounded-md border border-border/15",
+                          "flex size-7 flex-none items-center justify-center rounded-md",
                           style.icon
                         )}
                       >
-                        <Favicon
-                          domain={
-                            n.kind === "model"
-                              ? modelDomain(n.label, n.domain)
-                              : n.domain
-                          }
-                          className="size-3.5 rounded-sm"
-                          fallback={<Glyph className="size-3.5" stroke={2} />}
-                        />
+                        {n.kind === "model" ? (
+                          <ModelIcon
+                            label={n.label}
+                            domain={n.domain}
+                            className="size-3.5"
+                          />
+                        ) : (
+                          <Favicon
+                            domain={n.domain}
+                            className="size-3.5 rounded-sm"
+                            fallback={
+                              <Glyph
+                                className={cn("size-3.5", style.glyphClass)}
+                                stroke={2}
+                              />
+                            }
+                          />
+                        )}
                       </span>
                       <span className="flex min-w-0 flex-col">
                         <span className="truncate text-sm font-medium leading-snug">
@@ -431,26 +477,34 @@ export function FlowMap({
                     {n.embeds.length > 0 ? (
                       <div className="mx-4 flex flex-1 flex-col items-start gap-2 border-t border-muted pt-2.5">
                         {n.embeds.map((em) => {
-                          const EmGlyph = KIND_STYLES[em.kind].Glyph;
+                          const emStyle = KIND_STYLES[em.kind];
+                          const EmGlyph = emStyle.Glyph;
                           return (
                             <span
                               key={em.id}
                               className="flex max-w-full items-center gap-1.5"
                             >
-                              <Favicon
-                                domain={
-                                  em.kind === "model"
-                                    ? modelDomain(em.label, em.domain)
-                                    : em.domain
-                                }
-                                className="size-3.5 rounded-sm"
-                                fallback={
-                                  <EmGlyph
-                                    className="size-3.5 text-muted-foreground"
-                                    stroke={2}
-                                  />
-                                }
-                              />
+                              {em.kind === "model" ? (
+                                <ModelIcon
+                                  label={em.label}
+                                  domain={em.domain}
+                                  className="size-3.5"
+                                />
+                              ) : (
+                                <Favicon
+                                  domain={em.domain}
+                                  className="size-3.5 rounded-sm"
+                                  fallback={
+                                    <EmGlyph
+                                      className={cn(
+                                        "size-3.5 text-muted-foreground",
+                                        emStyle.glyphClass
+                                      )}
+                                      stroke={2}
+                                    />
+                                  }
+                                />
+                              )}
                               <span className="truncate text-xs font-medium">
                                 {em.label}
                               </span>
@@ -468,16 +522,16 @@ export function FlowMap({
       </div>
 
       {/* Detail popover for the traced node. Rendered OUTSIDE the pan/zoom
-          transform (positioned in screen space) so nothing on the map — edges,
-          labels, pulses — can ever paint over it, and it stays readable at any
-          zoom level. */}
+          transform (positioned in screen space) so nothing on the map can
+          paint over it, and it stays readable at any zoom level. */}
       {tracedNode ? (
         <motion.div
           key={tracedNode.id}
+          ref={popoverRef}
           className="border-overlay absolute z-30 w-60 rounded-xl bg-card p-3 shadow-(--custom-shadow)"
           style={{
-            left: t.x + tracedNode.x * t.k,
-            top: t.y + (tracedNode.y + tracedNode.height + 10) * t.k,
+            left: tNow.x + tracedNode.x * tNow.k,
+            top: tNow.y + (tracedNode.y + tracedNode.height + 10) * tNow.k,
           }}
           initial={{ opacity: 0, y: -4 }}
           animate={{ opacity: 1, y: 0 }}

--- a/apps/web/src/components/poster/kinds.tsx
+++ b/apps/web/src/components/poster/kinds.tsx
@@ -1,6 +1,6 @@
 // The fixed visual vocabulary for node kinds, expressed with the design system:
-// each kind maps to a Badge variant plus standard Tailwind palette classes for
-// the node's accent bar and icon tint. The agent only tags a node with a `kind`.
+// each kind maps to standard Tailwind palette classes for the node's icon tint,
+// legend dot, and pulse stroke. The agent only tags a node with a `kind`.
 
 import type { NodeKind } from "@foglamp/contracts/poster";
 import {
@@ -9,20 +9,18 @@ import {
   IconDatabaseFilled,
   IconGhostFilled,
   type IconProps,
-  IconSettingsFilled,
   IconSparklesFilled,
+  IconTool,
   IconWorldFilled,
 } from "@tabler/icons-react";
 import type { ComponentType } from "react";
 
-type BadgeVariant = "outline" | "amber" | "orange" | "blue" | "violet" | "emerald" | "rose";
-
 export interface KindStyle {
   label: string;
   Glyph: ComponentType<IconProps>;
-  /** Badge variant used for inline embeds and the legend. */
-  badge: BadgeVariant;
-  /** Left accent bar background. */
+  /** Extra classes for the glyph (e.g. fill outline icons). */
+  glyphClass?: string;
+  /** Legend dot / accent background. */
   bar: string;
   /** Node icon chip (tint background + foreground). */
   icon: string;
@@ -34,7 +32,6 @@ export const KIND_STYLES: Record<NodeKind, KindStyle> = {
   entry: {
     label: "Entry",
     Glyph: IconBoltFilled,
-    badge: "outline",
     bar: "bg-foreground/30",
     icon: "bg-muted text-foreground",
     hex: "#64748b",
@@ -42,7 +39,6 @@ export const KIND_STYLES: Record<NodeKind, KindStyle> = {
   cron: {
     label: "Cron",
     Glyph: IconClockFilled,
-    badge: "amber",
     bar: "bg-amber-500",
     icon: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
     hex: "#f59e0b",
@@ -50,7 +46,6 @@ export const KIND_STYLES: Record<NodeKind, KindStyle> = {
   agent: {
     label: "Agent",
     Glyph: IconGhostFilled,
-    badge: "orange",
     bar: "bg-orange-500",
     icon: "bg-orange-500/10 text-orange-600 dark:text-orange-400",
     hex: "#f97316",
@@ -58,15 +53,14 @@ export const KIND_STYLES: Record<NodeKind, KindStyle> = {
   model: {
     label: "Model",
     Glyph: IconSparklesFilled,
-    badge: "blue",
     bar: "bg-blue-500",
     icon: "bg-blue-500/10 text-blue-600 dark:text-blue-400",
     hex: "#3b82f6",
   },
   tool: {
     label: "Tool",
-    Glyph: IconSettingsFilled,
-    badge: "violet",
+    Glyph: IconTool,
+    glyphClass: "fill-current",
     bar: "bg-violet-500",
     icon: "bg-violet-500/10 text-violet-600 dark:text-violet-400",
     hex: "#8b5cf6",
@@ -74,7 +68,6 @@ export const KIND_STYLES: Record<NodeKind, KindStyle> = {
   store: {
     label: "Store",
     Glyph: IconDatabaseFilled,
-    badge: "emerald",
     bar: "bg-emerald-500",
     icon: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
     hex: "#10b981",
@@ -82,10 +75,9 @@ export const KIND_STYLES: Record<NodeKind, KindStyle> = {
   external: {
     label: "External",
     Glyph: IconWorldFilled,
-    badge: "rose",
-    bar: "bg-rose-500",
-    icon: "bg-rose-500/10 text-rose-600 dark:text-rose-400",
-    hex: "#f43f5e",
+    bar: "bg-sky-500",
+    icon: "bg-sky-500/10 text-sky-600 dark:text-sky-400",
+    hex: "#0ea5e9",
   },
 };
 
@@ -97,4 +89,18 @@ export const KIND_ORDER: NodeKind[] = [
   "tool",
   "store",
   "external",
+];
+
+/** Legend groups — fewer, friendlier categories than the raw kinds. */
+export const LEGEND_GROUPS: {
+  label: string;
+  kinds: NodeKind[];
+  dot: string;
+}[] = [
+  { label: "Triggers", kinds: ["entry", "cron"], dot: "bg-amber-500" },
+  { label: "Agents", kinds: ["agent"], dot: "bg-orange-500" },
+  { label: "Models", kinds: ["model"], dot: "bg-blue-500" },
+  { label: "Tools", kinds: ["tool"], dot: "bg-violet-500" },
+  { label: "Stores", kinds: ["store"], dot: "bg-emerald-500" },
+  { label: "External", kinds: ["external"], dot: "bg-sky-500" },
 ];

--- a/apps/web/src/components/poster/layout.ts
+++ b/apps/web/src/components/poster/layout.ts
@@ -48,9 +48,10 @@ export async function layoutGraph<T extends SizedNode>(
       "elk.direction": "RIGHT",
       "elk.edgeRouting": "ORTHOGONAL",
       "elk.layered.mergeEdges": "true",
-      "elk.layered.spacing.nodeNodeBetweenLayers": "88",
-      "elk.spacing.nodeNode": "32",
-      "elk.spacing.edgeNode": "24",
+      // Big graphs get tighter channels so deep pipelines don't sprawl.
+      "elk.layered.spacing.nodeNodeBetweenLayers": nodes.length > 16 ? "52" : "88",
+      "elk.spacing.nodeNode": nodes.length > 16 ? "22" : "32",
+      "elk.spacing.edgeNode": nodes.length > 16 ? "16" : "24",
       "elk.spacing.edgeEdge": "14",
       "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
       "elk.padding": "[top=16,left=16,bottom=16,right=16]",

--- a/apps/web/src/components/poster/left-rail.tsx
+++ b/apps/web/src/components/poster/left-rail.tsx
@@ -15,8 +15,9 @@ import {
 } from "@tabler/icons-react";
 import { type ComponentType, useEffect, useState } from "react";
 
-import { BrandMark, Favicon } from "./brand";
-import { modelDomain } from "./favicon";
+import { motion } from "motion/react";
+
+import { BrandMark, Favicon, ModelIcon } from "./brand";
 import { derivePersonality } from "./personality";
 
 function Stat({
@@ -116,9 +117,16 @@ export function LeftRail({ data }: { data: PosterData }) {
           <div className="absolute -top-8 -right-2 size-28 rounded-full bg-white/20 blur-2xl" />
           <div className="absolute -bottom-10 left-6 size-24 rounded-full bg-black/15 blur-2xl" />
           <div className="absolute top-4 left-1/2 size-10 rounded-full bg-white/10 blur-lg" />
-          <personality.Icon className="absolute -right-1 -bottom-7 size-24 rotate-12 text-white/20" />
+          <motion.span
+            className="absolute -right-1 -bottom-7"
+            initial={{ opacity: 0, scale: 0.5, rotate: -14 }}
+            animate={{ opacity: 1, scale: 1, rotate: 12 }}
+            transition={{ type: "spring", duration: 1.1, bounce: 0.3, delay: 0.35 }}
+          >
+            <personality.Icon className="size-24 text-white/20" />
+          </motion.span>
           <div className="absolute top-3 left-4 flex items-center gap-1 text-white">
-            <personality.Icon className="size-3.5 drop-shadow" />
+            <personality.Icon className="size-3.5 drop-shadow mb-px" />
             <span className="font-display text-sm font-semibold tracking-tight drop-shadow">
               {personality.title}
             </span>
@@ -138,7 +146,7 @@ export function LeftRail({ data }: { data: PosterData }) {
               domain={project.iconDomain}
               className="size-3.5 rounded-md"
               fallback={
-                <span className="font-display text-base font-bold drop-shadow">
+                <span className="flex size-3.5 items-center justify-center rounded-[4px] bg-white/25 font-display text-[9px] font-bold leading-none shadow-sm">
                   {project.name.charAt(0)}
                 </span>
               }
@@ -186,15 +194,10 @@ export function LeftRail({ data }: { data: PosterData }) {
             <ol className="flex list-none flex-col gap-3">
               {topModels.map((m, i) => (
                 <li key={m.id} className="flex items-center gap-2">
-                  <Favicon
-                    domain={modelDomain(m.label, m.domain)}
-                    className="size-3.5 rounded-sm"
-                    fallback={
-                      <IconBox
-                        className="size-3.5 text-muted-foreground"
-                        stroke={2}
-                      />
-                    }
+                  <ModelIcon
+                    label={m.label}
+                    domain={m.domain}
+                    className="size-3.5"
                   />
                   <span className="text-sm font-medium">{m.label}</span>
                 </li>

--- a/apps/web/src/components/poster/personality.ts
+++ b/apps/web/src/components/poster/personality.ts
@@ -1,7 +1,8 @@
 // Deterministic "personality" identity derived from the poster data — the
-// stats-as-identity hook (à la Arc's member card). Pure rules over data the
-// agent already emitted; same data → same card. Each archetype carries its own
-// palette + glyph so the rail's art block is unique per codebase shape.
+// stats-as-identity hook (à la Arc's member card). Every archetype is scored
+// on how *dominant* its trait is in this graph and the best score wins — a
+// first-match rule chain made almost everything an Orchestrator. Same data →
+// same card.
 
 import type { PosterData } from "@foglamp/contracts/poster";
 import {
@@ -10,11 +11,9 @@ import {
   IconBoltFilled,
   IconClockFilled,
   type IconProps,
+  IconGhostFilled,
   IconLeafFilled,
   IconSettingsFilled,
-  IconSparklesFilled,
-  IconGhost2Filled,
-  IconGhostFilled,
 } from "@tabler/icons-react";
 import type { ComponentType } from "react";
 
@@ -25,6 +24,44 @@ export interface Personality {
   gradient: string;
 }
 
+const ARCHETYPES = {
+  orchestrator: {
+    title: "Tireless Orchestrator",
+    Icon: IconGhostFilled,
+    gradient: "from-orange-500 to-amber-400",
+  },
+  scheduler: {
+    title: "Punctual Scheduler",
+    Icon: IconClockFilled,
+    gradient: "from-amber-500 to-yellow-400",
+  },
+  integrator: {
+    title: "Boundless Integrator",
+    Icon: IconAffiliateFilled,
+    gradient: "from-sky-500 to-cyan-400",
+  },
+  toolsmith: {
+    title: "Crafty Toolsmith",
+    Icon: IconSettingsFilled,
+    gradient: "from-violet-500 to-fuchsia-400",
+  },
+  archivist: {
+    title: "Meticulous Archivist",
+    Icon: IconArchiveFilled,
+    gradient: "from-emerald-500 to-teal-400",
+  },
+  minimalist: {
+    title: "Zen Minimalist",
+    Icon: IconLeafFilled,
+    gradient: "from-slate-500 to-zinc-400",
+  },
+  builder: {
+    title: "Steady Builder",
+    Icon: IconBoltFilled,
+    gradient: "from-blue-500 to-sky-400",
+  },
+} satisfies Record<string, Personality>;
+
 export function derivePersonality(data: PosterData): Personality {
   const { stats, graph } = data;
   const kindCount = (k: string) =>
@@ -32,47 +69,35 @@ export function derivePersonality(data: PosterData): Personality {
   const crons = kindCount("cron");
   const externals = kindCount("external");
   const stores = kindCount("store");
+  const nodes = Math.max(graph.nodes.length, 1);
 
-  // First matching rule wins, most distinctive shapes first.
-  if (stats.agents >= 5)
-    return {
-      title: "Tireless Orchestrator",
-      Icon: IconGhostFilled,
-      gradient: "from-orange-500 to-amber-400",
-    };
-  if (crons >= 3)
-    return {
-      title: "Punctual Scheduler",
-      Icon: IconClockFilled,
-      gradient: "from-amber-500 to-yellow-400",
-    };
-  if (externals >= 4)
-    return {
-      title: "Boundless Integrator",
-      Icon: IconAffiliateFilled,
-      gradient: "from-rose-500 to-orange-400",
-    };
-  if (stats.tools > stats.agents * 2 && stats.tools >= 4)
-    return {
-      title: "Crafty Toolsmith",
-      Icon: IconSettingsFilled,
-      gradient: "from-violet-500 to-fuchsia-400",
-    };
-  if (stores >= 3)
-    return {
-      title: "Meticulous Archivist",
-      Icon: IconArchiveFilled,
-      gradient: "from-emerald-500 to-teal-400",
-    };
-  if (stats.agents === 1 && stats.models === 1)
-    return {
-      title: "Zen Minimalist",
-      Icon: IconLeafFilled,
-      gradient: "from-slate-500 to-zinc-400",
-    };
-  return {
-    title: "Steady Builder",
-    Icon: IconBoltFilled,
-    gradient: "from-blue-500 to-sky-400",
-  };
+  // 0..~1.1 per archetype — ratios and saturation points chosen so a single
+  // huge count can't sweep every board.
+  const scores: [keyof typeof ARCHETYPES, number][] = [
+    // Agent-dense graphs. Saturates at 8 and is discounted when agents are a
+    // small share of an otherwise sprawling map.
+    [
+      "orchestrator",
+      Math.min(stats.agents / 8, 1) * 0.7 + (stats.agents / nodes) * 0.5,
+    ],
+    // Several scheduled jobs is genuinely rare and distinctive.
+    ["scheduler", Math.min(crons / 3, 1) * 1.1],
+    // A web of third-party services.
+    ["integrator", Math.min(externals / 5, 1) * 1.05],
+    // The toolbox outshines the agents.
+    [
+      "toolsmith",
+      stats.tools >= 3
+        ? Math.min(stats.tools / Math.max(stats.agents, 1), 2) * 0.55
+        : 0,
+    ],
+    // Data-heavy: several distinct stores.
+    ["archivist", Math.min(stores / 3, 1) * 1.05],
+    // Tiny, focused graphs.
+    ["minimalist", nodes <= 6 && stats.agents <= 2 ? 1 : 0],
+  ];
+
+  scores.sort((a, b) => b[1] - a[1]);
+  const [best, score] = scores[0]!;
+  return score >= 0.5 ? ARCHETYPES[best] : ARCHETYPES.builder;
 }

--- a/apps/web/src/components/poster/poster-board.tsx
+++ b/apps/web/src/components/poster/poster-board.tsx
@@ -13,17 +13,17 @@ export function PosterBoard({ data }: { data: PosterData }) {
   const kinds = KIND_ORDER.filter((k) =>
     data.graph.nodes.some((n) => n.kind === k)
   );
-  // Clicking a legend item spotlights only that kind on the map.
-  const [focusKind, setFocusKind] = useState<NodeKind | null>(null);
+  // Hovering a legend group spotlights those kinds on the map.
+  const [focusKinds, setFocusKinds] = useState<NodeKind[] | null>(null);
 
   return (
     <div className="fixed inset-0 overflow-hidden bg-neutral-100 text-foreground dark:bg-background">
       <LeftRail data={data} />
-      <FlowMap graph={data.graph} focusKind={focusKind} />
+      <FlowMap graph={data.graph} focusKinds={focusKinds} />
       <ShareBar
         kinds={kinds}
-        focusKind={focusKind}
-        onFocusKind={(k) => setFocusKind((cur) => (cur === k ? null : k))}
+        focusKinds={focusKinds}
+        onFocusKinds={setFocusKinds}
       />
     </div>
   );

--- a/apps/web/src/components/poster/share-bar.tsx
+++ b/apps/web/src/components/poster/share-bar.tsx
@@ -8,7 +8,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useTheme } from "next-themes";
 import { type ReactNode, useEffect, useState } from "react";
 
-import { KIND_STYLES } from "./kinds";
+import { LEGEND_GROUPS } from "./kinds";
 
 // Swap between two icons with the same spring blur/scale transition as
 // components/app/copy-icon.tsx. `swapKey` drives the enter/exit.
@@ -33,12 +33,12 @@ function IconSwap({ swapKey, children }: { swapKey: string; children: ReactNode 
 
 export function ShareBar({
   kinds,
-  focusKind,
-  onFocusKind,
+  focusKinds,
+  onFocusKinds,
 }: {
   kinds: NodeKind[];
-  focusKind: NodeKind | null;
-  onFocusKind: (kind: NodeKind) => void;
+  focusKinds: NodeKind[] | null;
+  onFocusKinds: (kinds: NodeKind[] | null) => void;
 }) {
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -59,19 +59,24 @@ export function ShareBar({
 
   return (
     <>
-      {/* Legend — floats bare on the canvas, top-right. Click to spotlight a kind. */}
+      {/* Legend — bottom center, grouped categories. Hovering a group
+          spotlights every node of (or embedding) those kinds. */}
       {kinds.length > 0 ? (
-        <div className="fixed top-6 right-6 z-50 flex items-center gap-3">
-          {kinds.map((k) => {
-            const active = focusKind === k;
-            const dimmed = focusKind !== null && !active;
+        <div className="fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-4">
+          {LEGEND_GROUPS.filter((g) =>
+            g.kinds.some((k) => kinds.includes(k))
+          ).map((g) => {
+            const active =
+              focusKinds !== null && g.kinds.some((k) => focusKinds.includes(k));
+            const dimmed = focusKinds !== null && !active;
             return (
               <button
-                key={k}
+                key={g.label}
                 type="button"
-                onClick={() => onFocusKind(k)}
+                onMouseEnter={() => onFocusKinds(g.kinds)}
+                onMouseLeave={() => onFocusKinds(null)}
                 className={cn(
-                  "flex cursor-pointer items-center gap-1 text-[10px] font-medium uppercase tracking-wider transition-all",
+                  "flex cursor-default items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider transition-all",
                   active
                     ? "text-foreground"
                     : "text-muted-foreground/70 hover:text-foreground",
@@ -81,11 +86,11 @@ export function ShareBar({
                 <span
                   className={cn(
                     "size-1.5 rounded-full transition-transform",
-                    KIND_STYLES[k].bar,
+                    g.dot,
                     active ? "scale-125" : "opacity-80"
                   )}
                 />
-                {KIND_STYLES[k].label}
+                {g.label}
               </button>
             );
           })}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -38,3 +38,16 @@
 .dark .border-overlay {
   outline-color: rgba(255, 255, 255, 0.1);
 }
+
+/* Poster map edge pulses — CSS-driven so dozens of edges don't each run a JS
+   animation loop. Offset matches the "4 156" dash pattern (one period = 160). */
+@keyframes poster-pulse {
+  to {
+    stroke-dashoffset: -160;
+  }
+}
+@keyframes poster-fade {
+  to {
+    opacity: 1;
+  }
+}

--- a/apps/web/src/lib/poster-prompt.ts
+++ b/apps/web/src/lib/poster-prompt.ts
@@ -54,8 +54,13 @@ a map of how the codebase works and how it uses AI. You produce only the data
 }
 
 ## Rules (these keep every poster consistent — do not break them)
-- Caps: topModels <= 3, topTools <= 5, topIntegrations <= 5, graph.nodes <= 18,
-  graph.edges <= 32. PRIORITIZE the most important items; do not dump everything.
+- Caps: topModels <= 3, topTools <= 5, topIntegrations <= 5, graph.nodes <= 24,
+  graph.edges <= 48. Aim for 14-22 nodes on a substantial codebase — the map
+  should feel rich, not sparse.
+- Give every distinct agent its OWN node when there are <= 10 agents; only
+  group agents when they are numerous and near-identical (then say so in sub,
+  e.g. "12 near-identical scrapers"). Chain agents with agent->agent edges when
+  one feeds the next — pipelines read better than hub-and-spoke.
 - Node labels <= 28 chars, sub <= 40, edge labels <= 24.
 - kind is one of: entry (trigger/route/page/CLI), cron (scheduled job), agent,
   model, tool, store (DB/cache/index), external (3rd-party API).

--- a/packages/contracts/src/poster.ts
+++ b/packages/contracts/src/poster.ts
@@ -112,8 +112,8 @@ export const PosterData = z
     /** The flow map. Capped so the deterministic layout always fits the canvas. */
     graph: z
       .object({
-        nodes: z.array(GraphNode).min(1).max(18),
-        edges: z.array(GraphEdge).max(32).default([]),
+        nodes: z.array(GraphNode).min(1).max(24),
+        edges: z.array(GraphEdge).max(48).default([]),
       })
       .refine(
         (g) => {


### PR DESCRIPTION
Personality scoring, grouped hover legend, imperative pan/zoom perf, CSS pulses, brand model marks, fit fixes, contract caps 24/48 + prompt guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh