### PR TITLE
feat(hud): marketing page + live playground at /hud

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -145,5 +145,9 @@ jobs:
             curl -sf -o /dev/null -w "ingest %{http_code}\n" https://ingest.foglamp.dev/health || true
           fi
           if [ "${{ steps.changes.outputs.hud }}" = "true" ]; then
+            # `/` now 302s to foglamp.dev/hud; the thing the marketing page
+            # depends on is the SSE stream, so probe that (bounded — it never
+            # ends on its own).
+            curl -s -o /dev/null --max-time 3 https://hud.foglamp.dev/hud/events || true
             curl -sf -o /dev/null -w "hud %{http_code}\n" https://hud.foglamp.dev/ || true
           fi

--- a/apps/web/src/app/(marketing)/hud/page.tsx
+++ b/apps/web/src/app/(marketing)/hud/page.tsx
@@ -1,33 +1,87 @@
 import type { Metadata } from "next";
 
+import { HudPlayground } from "@/components/marketing/hud/hud-playground";
+import { FilmGrain } from "@/components/marketing/noise-overlay";
+
 export const metadata: Metadata = {
   title: "HUD",
   description:
-    "A live heads-up display for your AI agents while you build. See every call as it happens, right in your app.",
+    "A live heads-up display for your AI agents while you build. Every call, tool step and retry, right in your app. Try it in the browser.",
+  alternates: { canonical: "/hud" },
 };
 
-// Placeholder page so /hud exists for the navbar and footer. Replaced by the
-// full marketing page + live playground in the follow-up PR.
+const DOCS_URL = "https://docs.foglamp.dev/sdk/hud";
+
+// The HUD page IS the playground: the real FoglampHUD component floats in the
+// corner of this page, streaming live mock agents from the always-on demo
+// service. The copy explains what you're looking at.
 export default function HudPage() {
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col gap-4 px-5 py-28 sm:px-8">
-      <h1 className="font-display text-4xl font-semibold tracking-tight">
-        The Foglamp HUD
-      </h1>
-      <p className="max-w-md text-lg text-muted-foreground">
-        A live heads-up display for your agents while you build. The full page,
-        with a playground you can try in the browser, is landing here shortly.
-      </p>
-      <p className="text-muted-foreground">
-        In the meantime, try the live demo at{" "}
-        <a
-          href="https://hud.foglamp.dev"
-          className="text-foreground underline decoration-foreground/20 underline-offset-4 hover:decoration-foreground"
-        >
-          hud.foglamp.dev
-        </a>
-        .
-      </p>
+    <div className="flex flex-col gap-24 pb-32">
+      <section className="relative isolate w-full overflow-x-clip pt-28">
+        <FilmGrain id="hud-noise" className="-z-10 opacity-10 mix-blend-screen" />
+        <div className="mx-auto w-full max-w-7xl px-5 sm:px-8">
+          <p className="text-sm font-medium tracking-wide text-orange-500">
+            Foglamp HUD
+          </p>
+          <h1 className="font-display mt-4 max-w-2xl text-4xl font-semibold tracking-tight text-balance md:text-5xl">
+            See your agents while you build.
+          </h1>
+          <p className="mt-5 max-w-md text-lg text-muted-foreground text-pretty">
+            The dashboard watches production. The HUD watches your dev loop:
+            every call, tool step and retry, live in the corner of your app.
+          </p>
+
+          <div className="mt-10 flex flex-col gap-3">
+            <p className="max-w-md text-sm text-muted-foreground text-pretty">
+              It is already running on this page, streaming a handful of demo
+              agents. Open the pill in the corner, then hit the button:
+            </p>
+            <HudPlayground />
+          </div>
+
+          <div className="mt-20 grid max-w-4xl gap-12 md:grid-cols-3 md:gap-8">
+            <div>
+              <h3 className="font-display text-lg font-semibold tracking-tight">
+                Zero setup
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground text-pretty">
+                It ships inside the SDK. When your agent wires Foglamp up, the
+                HUD comes with it. Nothing to install, nothing to deploy.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-display text-lg font-semibold tracking-tight">
+                Local by default
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground text-pretty">
+                Traces stream to the overlay on your machine. No API key, no
+                data leaves your laptop. It turns itself off in production.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-display text-lg font-semibold tracking-tight">
+                The full story
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground text-pretty">
+                Timeline, tool calls, retries, cost per run. When something
+                fails you watch it fail, instead of digging through logs.
+              </p>
+            </div>
+          </div>
+
+          <p className="mt-16 text-sm text-muted-foreground">
+            Want the details?{" "}
+            <a
+              href={DOCS_URL}
+              className="text-foreground underline decoration-foreground/20 underline-offset-4 hover:decoration-foreground"
+            >
+              Read the HUD docs
+            </a>
+            .
+          </p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/web/src/components/marketing/hud/hud-playground.tsx
+++ b/apps/web/src/components/marketing/hud/hud-playground.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Button } from "@foglamp/ui/components/button";
+import { IconBoltFilled } from "@tabler/icons-react";
+import dynamic from "next/dynamic";
+import { useState } from "react";
+
+// The real HUD component from the published SDK, pointed at the always-on
+// mock-agent demo (Cloud Run). It portals itself to the corner of THIS page,
+// so visitors see the actual product overlaying the marketing copy. Client
+// only: it opens an EventSource and has no server render.
+const FoglampHUD = dynamic(
+  () => import("foglamp/hud").then((m) => m.FoglampHUD),
+  { ssr: false, loading: () => null }
+);
+
+const DEMO_ORIGIN = "https://hud.foglamp.dev";
+
+export function HudPlayground() {
+  const [state, setState] = useState<"idle" | "running" | "down">("idle");
+
+  async function runStorm() {
+    setState("running");
+    try {
+      const res = await fetch(`${DEMO_ORIGIN}/api/storm`, {
+        method: "POST",
+        mode: "cors",
+      });
+      if (!res.ok) throw new Error(String(res.status));
+      setTimeout(() => setState("idle"), 8000);
+    } catch {
+      setState("down");
+    }
+  }
+
+  return (
+    <>
+      <FoglampHUD url={`${DEMO_ORIGIN}/hud/events`} defaultOpen />
+      <div className="flex flex-wrap items-center gap-3">
+        <Button size="lg" className="text-base" onClick={runStorm}>
+          <IconBoltFilled className="size-4" />
+          Run an agent storm
+        </Button>
+        {state === "running" ? (
+          <span className="text-sm text-muted-foreground">
+            Storm incoming. Watch the HUD in the corner.
+          </span>
+        ) : null}
+        {state === "down" ? (
+          <span className="text-sm text-muted-foreground">
+            The live demo is taking a nap. Try again in a minute.
+          </span>
+        ) : null}
+      </div>
+    </>
+  );
+}

--- a/examples/hud-demo/DEPLOY.md
+++ b/examples/hud-demo/DEPLOY.md
@@ -77,7 +77,16 @@ out-of-band push.
 ## Smoke test
 
 ```bash
-curl -sf https://hud.foglamp.dev/ -o /dev/null && echo "page ok"
-# SSE stream (should stay open and stream events):
+# `/` 302s to the canonical marketing page at foglamp.dev/hud:
+curl -s -o /dev/null -w "%{http_code} %{redirect_url}\n" https://hud.foglamp.dev/
+# SSE stream (should stay open and stream events; CORS `*` for foglamp.dev):
 curl -N https://hud.foglamp.dev/hud/events
 ```
+
+## Relationship to foglamp.dev/hud
+
+The marketing page at `foglamp.dev/hud` embeds `<FoglampHUD url="https://hud.foglamp.dev/hud/events" />`
+cross-origin and triggers `POST /api/storm` from the browser — that's why the
+SSE proxy and API routes send CORS headers, and why this service must stay
+always-on. This origin is no longer a standalone landing page; its root
+redirects to the marketing page.

--- a/examples/hud-demo/src/server.ts
+++ b/examples/hud-demo/src/server.ts
@@ -36,30 +36,56 @@ function clientIp(req: Request, server: { requestIP(r: Request): { address: stri
   );
 }
 
+// The stream and triggers are consumed cross-origin by foglamp.dev/hud (the
+// marketing playground). Public, read-only, no credentials — a wildcard is fine.
+const CORS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, POST, OPTIONS",
+  "access-control-allow-headers": "content-type",
+} as const;
+
 Bun.serve({
   port: PORT,
   idleTimeout: 0, // don't drop the long-lived SSE proxy connection
   async fetch(req, server) {
     const url = new URL(req.url);
 
+    // CORS preflight for the cross-origin POSTs from foglamp.dev/hud.
+    if (req.method === "OPTIONS") return new Response(null, { headers: CORS });
+
     // Proxy the broker's SSE onto this origin so the browser can subscribe.
     // Same host → the loopback broker is reachable; Bun streams the response.
     if (req.method === "GET" && url.pathname === "/hud/events") {
-      return fetch(BROKER_SSE, { signal: req.signal });
+      const upstream = await fetch(BROKER_SSE, { signal: req.signal });
+      return new Response(upstream.body, {
+        status: upstream.status,
+        headers: {
+          ...Object.fromEntries(upstream.headers),
+          ...CORS,
+        },
+      });
     }
 
     if (req.method === "POST" && (url.pathname === "/api/run" || url.pathname === "/api/storm")) {
-      if (!allow(clientIp(req, server))) return new Response("slow down", { status: 429 });
+      if (!allow(clientIp(req, server)))
+        return new Response("slow down", { status: 429, headers: CORS });
       if (url.pathname === "/api/storm") runStorm();
       else {
         const id = url.searchParams.get("agent");
         if (id) runAgent(id).catch((e) => console.error("run failed:", e));
       }
-      return new Response("ok");
+      return new Response("ok", { headers: CORS });
+    }
+
+    // The canonical marketing page for the HUD lives on the main site now;
+    // the standalone demo root just points there. The SSE + API routes above
+    // keep serving on this origin.
+    if (req.method === "GET" && url.pathname === "/") {
+      return Response.redirect("https://foglamp.dev/hud", 302);
     }
 
     // Static assets from the Vite build; SPA fallback to index.html.
-    const rel = url.pathname === "/" ? "index.html" : url.pathname.replace(/^\//, "");
+    const rel = url.pathname.replace(/^\//, "");
     const file = Bun.file(new URL(rel, DIST));
     if (await file.exists()) return new Response(file);
     return new Response(Bun.file(new URL("index.html", DIST)), {


### PR DESCRIPTION
foglamp.dev/hud now hosts the HUD story with the real FoglampHUD component streaming the Cloud Run mock-agent demo, plus a storm trigger. The demo server gains CORS for the cross-origin embed and its root redirects to the marketing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh