### PR TITLE
fix(marketing): clip footer fog (page overflow), feather CTA fog

### DIFF
--- a/apps/web/src/components/marketing/footer-fog.tsx
+++ b/apps/web/src/components/marketing/footer-fog.tsx
@@ -4,24 +4,30 @@ import { motion, useReducedMotion } from "motion/react";
 
 import { FogBank } from "./noise-overlay";
 
-// A thin, slow fog band hugging the footer's bottom edge — it fades out just
-// under the copyright row. Very low opacity; reduced-motion users get it still.
+// A thin fog band hugging the footer's bottom edge — it fades out just under
+// the copyright row. overflow-hidden is load-bearing: the drifting layer is
+// oversized, and without clipping it stretches the page's scroll area (a
+// horizontal scrollbar and a phantom gap under the footer).
 export function FooterFog() {
   const reduce = useReducedMotion() ?? false;
   return (
     <div
       aria-hidden
-      className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-24 opacity-30"
+      className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-24 overflow-hidden opacity-30"
       style={{
         WebkitMaskImage: "linear-gradient(to top, #000 30%, transparent)",
         maskImage: "linear-gradient(to top, #000 30%, transparent)",
       }}
     >
       <motion.div
-        className="absolute inset-[-30%]"
-        style={{ filter: "blur(14px)" }}
-        animate={reduce ? undefined : { x: ["-2%", "3%", "-2%"] }}
-        transition={{ duration: 40, repeat: Infinity, ease: "easeInOut" }}
+        className="absolute inset-[-40%]"
+        style={{ filter: "blur(12px)" }}
+        animate={
+          reduce
+            ? undefined
+            : { x: ["-6%", "6%", "-6%"], y: ["-4%", "4%", "-4%"] }
+        }
+        transition={{ duration: 13, repeat: Infinity, ease: "easeInOut" }}
       >
         <FogBank id="footer-fog" freq={0.014} seed={11} />
       </motion.div>

--- a/apps/web/src/components/marketing/landing/cta.tsx
+++ b/apps/web/src/components/marketing/landing/cta.tsx
@@ -34,20 +34,29 @@ export function CtaSection() {
         }}
       />
 
-      {/* The fog blanket: drifting turbulence, masked with a soft ellipse so
-          it fades out gently on every side (no hard band edges) and thins out
-          behind the copy on the left. */}
+      {/* The fog blanket: drifting turbulence. Two nested masks (vertical on
+          the outer div, horizontal on the inner) multiply together, so the fog
+          feathers to zero well before every edge — no hard cuts anywhere. */}
       {!reduce && (
         <div
           className="absolute inset-0 z-10"
           aria-hidden
           style={{
             WebkitMaskImage:
-              "radial-gradient(85% 75% at 62% 50%, #000 25%, transparent 78%)",
+              "linear-gradient(to bottom, transparent 2%, #000 38%, #000 62%, transparent 98%)",
             maskImage:
-              "radial-gradient(85% 75% at 62% 50%, #000 25%, transparent 78%)",
+              "linear-gradient(to bottom, transparent 2%, #000 38%, #000 62%, transparent 98%)",
           }}
         >
+          <div
+            className="absolute inset-0"
+            style={{
+              WebkitMaskImage:
+                "linear-gradient(to right, transparent 8%, #000 45%, #000 78%, transparent 99%)",
+              maskImage:
+                "linear-gradient(to right, transparent 8%, #000 45%, #000 78%, transparent 99%)",
+            }}
+          >
           <motion.div
             className="absolute inset-[-20%] opacity-50"
             style={{ filter: "blur(14px)" }}
@@ -64,6 +73,7 @@ export function CtaSection() {
           >
             <FogBank id="fog-b" freq={0.02} seed={29} octaves={5} />
           </motion.div>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Fixes the horizontal scroll + gap under the footer (unclipped oversized fog layer), fully feathers the CTA fog with nested masks, speeds up the footer fog drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh