### PR TITLE
fix(marketing): remove fog tint drift

### DIFF
--- a/apps/web/src/components/marketing/footer-fog.tsx
+++ b/apps/web/src/components/marketing/footer-fog.tsx
@@ -38,7 +38,7 @@ export function FooterFog() {
           }
           transition={{ duration: 22, repeat: Infinity, ease: "easeInOut" }}
         >
-          <FogBank id="footer-fog" freq={0.014} seed={11} shimmer={!reduce} />
+          <FogBank id="footer-fog" freq={0.014} seed={11} />
         </motion.div>
       ) : null}
     </div>

--- a/apps/web/src/components/marketing/landing/cta.tsx
+++ b/apps/web/src/components/marketing/landing/cta.tsx
@@ -75,7 +75,7 @@ export function CtaSection() {
             animate={{ x: ["-3%", "4%", "-3%"], y: ["-2%", "2%", "-2%"] }}
             transition={{ duration: 26, repeat: Infinity, ease: "easeInOut" }}
           >
-            <FogBank id="fog-a" freq={0.011} seed={7} shimmer />
+            <FogBank id="fog-a" freq={0.011} seed={7}/>
           </motion.div>
           <motion.div
             className="absolute inset-[-15%] opacity-20"
@@ -89,7 +89,7 @@ export function CtaSection() {
             animate={{ x: ["3%", "-4%", "3%"], y: ["2%", "-3%", "2%"] }}
             transition={{ duration: 34, repeat: Infinity, ease: "easeInOut" }}
           >
-            <FogBank id="fog-b" freq={0.02} seed={19} octaves={5} shimmer />
+            <FogBank id="fog-b" freq={0.02} seed={19} octaves={5}/>
           </motion.div>
           <motion.div
             className="absolute inset-[-15%] opacity-5"
@@ -103,7 +103,7 @@ export function CtaSection() {
             animate={{ x: ["-2%", "3%", "-2%"], y: ["3%", "-2%", "3%"] }}
             transition={{ duration: 41, repeat: Infinity, ease: "easeInOut" }}
           >
-            <FogBank id="fog-c" freq={0.016} seed={53} octaves={4} shimmer />
+            <FogBank id="fog-c" freq={0.016} seed={53} octaves={4}/>
           </motion.div>
           {/* bottom-right filler */}
           <motion.div
@@ -118,7 +118,7 @@ export function CtaSection() {
             animate={{ x: ["2%", "-3%", "2%"], y: ["-2%", "3%", "-2%"] }}
             transition={{ duration: 30, repeat: Infinity, ease: "easeInOut" }}
           >
-            <FogBank id="fog-d" freq={0.014} seed={83} octaves={4} shimmer />
+            <FogBank id="fog-d" freq={0.014} seed={83} octaves={4}/>
           </motion.div>
           {/* a denser puff right on top of the agent details, so they read as
               half-swallowed by the fog */}
@@ -134,7 +134,7 @@ export function CtaSection() {
             animate={{ x: ["-2%", "2%", "-2%"], y: ["1%", "-2%", "1%"] }}
             transition={{ duration: 24, repeat: Infinity, ease: "easeInOut" }}
           >
-            <FogBank id="fog-e" freq={0.018} seed={47} octaves={5} shimmer />
+            <FogBank id="fog-e" freq={0.018} seed={47} octaves={5}/>
           </motion.div>
         </div>
       )}

--- a/apps/web/src/components/marketing/noise-overlay.tsx
+++ b/apps/web/src/components/marketing/noise-overlay.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { cn } from "@foglamp/ui/lib/utils";
-import { motion, useReducedMotion } from "motion/react";
 
 // Shared atmospheric textures for marketing sections. Two flavors:
 // - FilmGrain: a static feTurbulence speckle applied to the element itself via
@@ -40,21 +39,12 @@ export function FogBank({
   freq,
   seed,
   octaves = 4,
-  shimmer = false,
 }: {
   id: string;
   freq: number;
   seed: number;
   octaves?: number;
-  /**
-   * Slowly drift the fog toward a warmer grey and back. Implemented as a
-   * compositor-only opacity fade on a tint overlay (NOT an SVG filter
-   * animation — animating the filter re-rasterizes the turbulence every
-   * frame and melts CPUs). Callers should gate this on reduced motion.
-   */
-  shimmer?: boolean;
 }) {
-  const reduce = useReducedMotion() ?? false;
   return (
     <div aria-hidden className="absolute inset-0 overflow-hidden">
       {/* The turbulence is rasterized at quarter resolution and scaled up 4x.
@@ -82,17 +72,6 @@ export function FogBank({
         </filter>
         <rect width="100%" height="100%" filter={`url(#${id})`} />
       </svg>
-      {/* Warm tint drift: a soft-light color wash whose opacity breathes.
-          Opacity animation composites on the GPU; the fog raster is untouched. */}
-      {shimmer && !reduce ? (
-        <motion.div
-          className="absolute inset-0 mix-blend-soft-light"
-          style={{ background: "rgb(214,190,160)" }}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: [0, 0.35, 0] }}
-          transition={{ duration: 21, repeat: Infinity, ease: "easeInOut" }}
-        />
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Drops the color-changing overlay; fog keeps only its positional drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh