### PR TITLE
feat(marketing): standardize Scan + HUD product pages

### DIFF
--- a/apps/web/src/app/(marketing)/hud/page.tsx
+++ b/apps/web/src/app/(marketing)/hud/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 
 import { HudPlayground } from "@/components/marketing/hud/hud-playground";
-import { FilmGrain } from "@/components/marketing/noise-overlay";
+import { CtaSection } from "@/components/marketing/landing/cta";
+import { HeroGrain } from "@/components/marketing/noise-overlay";
 
 export const metadata: Metadata = {
   title: "HUD",
@@ -12,14 +13,15 @@ export const metadata: Metadata = {
 
 const DOCS_URL = "https://docs.foglamp.dev/sdk/hud";
 
-// The HUD page IS the playground: the real FoglampHUD component floats in the
-// corner of this page, streaming live mock agents from the always-on demo
-// service. The copy explains what you're looking at.
+// Standard product-page structure (same as /scan): hero, showcase, CTA. The
+// real FoglampHUD floats over the whole page, streaming live mock agents from
+// the always-on demo service — the page itself is the playground.
 export default function HudPage() {
   return (
-    <div className="flex flex-col gap-24 pb-32">
+    <div className="flex flex-col gap-36">
+      {/* Hero */}
       <section className="relative isolate w-full overflow-x-clip pt-28">
-        <FilmGrain id="hud-noise" className="-z-10 opacity-10 mix-blend-screen" />
+        <HeroGrain id="hud-noise" />
         <div className="mx-auto w-full max-w-7xl px-5 sm:px-8">
           <p className="text-sm font-medium tracking-wide text-orange-500">
             Foglamp HUD
@@ -32,56 +34,62 @@ export default function HudPage() {
             every call, tool step and retry, live in the corner of your app.
           </p>
 
-          <div className="mt-10 flex flex-col gap-3">
+          <div className="mt-8 flex flex-col gap-3">
             <p className="max-w-md text-sm text-muted-foreground text-pretty">
               It is already running on this page, streaming a handful of demo
               agents. Open the pill in the corner, then hit the button:
             </p>
             <HudPlayground />
           </div>
-
-          <div className="mt-20 grid max-w-4xl gap-12 md:grid-cols-3 md:gap-8">
-            <div>
-              <h3 className="font-display text-lg font-semibold tracking-tight">
-                Zero setup
-              </h3>
-              <p className="mt-2 text-sm text-muted-foreground text-pretty">
-                It ships inside the SDK. When your agent wires Foglamp up, the
-                HUD comes with it. Nothing to install, nothing to deploy.
-              </p>
-            </div>
-            <div>
-              <h3 className="font-display text-lg font-semibold tracking-tight">
-                Local by default
-              </h3>
-              <p className="mt-2 text-sm text-muted-foreground text-pretty">
-                Traces stream to the overlay on your machine. No API key, no
-                data leaves your laptop. It turns itself off in production.
-              </p>
-            </div>
-            <div>
-              <h3 className="font-display text-lg font-semibold tracking-tight">
-                The full story
-              </h3>
-              <p className="mt-2 text-sm text-muted-foreground text-pretty">
-                Timeline, tool calls, retries, cost per run. When something
-                fails you watch it fail, instead of digging through logs.
-              </p>
-            </div>
-          </div>
-
-          <p className="mt-16 text-sm text-muted-foreground">
-            Want the details?{" "}
-            <a
-              href={DOCS_URL}
-              className="text-foreground underline decoration-foreground/20 underline-offset-4 hover:decoration-foreground"
-            >
-              Read the HUD docs
-            </a>
-            .
-          </p>
         </div>
       </section>
+
+      {/* Showcase */}
+      <section className="mx-auto w-full max-w-7xl px-5 sm:px-8">
+        <div className="grid max-w-4xl gap-12 md:grid-cols-3 md:gap-8">
+          <div>
+            <h3 className="font-display text-lg font-semibold tracking-tight">
+              Zero setup
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground text-pretty">
+              It ships inside the SDK. When your agent wires Foglamp up, the
+              HUD comes with it. Nothing to install, nothing to deploy.
+            </p>
+          </div>
+          <div>
+            <h3 className="font-display text-lg font-semibold tracking-tight">
+              Local by default
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground text-pretty">
+              Traces stream to the overlay on your machine. No API key, no
+              data leaves your laptop. It turns itself off in production.
+            </p>
+          </div>
+          <div>
+            <h3 className="font-display text-lg font-semibold tracking-tight">
+              The full story
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground text-pretty">
+              Timeline, tool calls, retries, cost per run. When something
+              fails you watch it fail, instead of digging through logs.
+            </p>
+          </div>
+        </div>
+
+        <p className="mt-14 text-sm text-muted-foreground">
+          Want the details?{" "}
+          <a
+            href={DOCS_URL}
+            className="text-foreground underline decoration-foreground/20 underline-offset-4 hover:decoration-foreground"
+          >
+            Read the HUD docs
+          </a>
+          .
+        </p>
+      </section>
+
+      {/* CTA */}
+      <CtaSection />
     </div>
   );
 }

--- a/apps/web/src/app/(marketing)/scan/page.tsx
+++ b/apps/web/src/app/(marketing)/scan/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 export default function ScanLandingPage() {
   return (
-    <div className="flex flex-col gap-24 pb-32">
+    <div className="flex flex-col gap-36">
       <ScanHero />
       <ScanStory />
       <CtaSection />

--- a/apps/web/src/app/(marketing)/scan/scan-hero.tsx
+++ b/apps/web/src/app/(marketing)/scan/scan-hero.tsx
@@ -4,7 +4,7 @@ import type { ScanData } from "@foglamp/contracts/scan";
 import { type MotionProps, motion, useReducedMotion } from "motion/react";
 import dynamic from "next/dynamic";
 
-import { FilmGrain } from "@/components/marketing/noise-overlay";
+import { HeroGrain } from "@/components/marketing/noise-overlay";
 import { CopyScanPromptButton } from "./copy-scan-prompt-button";
 
 const EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
@@ -90,13 +90,8 @@ export function ScanHero() {
 
   return (
     <section className="relative isolate w-full overflow-x-clip pt-28 pb-10">
-      {/* Same film-grain treatment as the main hero. */}
-      <FilmGrain id="scan-hero-noise" className="-z-10 opacity-10 mix-blend-screen" />
-      {/* faint map grid behind the hero, fading out downward */}
-      <div
-        aria-hidden
-        className="absolute inset-0 -z-10 bg-[linear-gradient(color-mix(in_oklab,var(--border)_28%,transparent)_1px,transparent_1px),linear-gradient(90deg,color-mix(in_oklab,var(--border)_28%,transparent)_1px,transparent_1px)] bg-size-[56px_56px] [background-position:center] [mask-image:linear-gradient(to_bottom,#000_20%,transparent_90%)]"
-      />
+      {/* Same grain treatment as the landing hero. */}
+      <HeroGrain id="scan-hero-noise" />
       <div className="mx-auto flex max-w-7xl items-center justify-between gap-12 px-5 sm:px-8">
         <div className="max-w-xl shrink-0">
           <motion.p

--- a/apps/web/src/components/marketing/noise-overlay.tsx
+++ b/apps/web/src/components/marketing/noise-overlay.tsx
@@ -75,3 +75,22 @@ export function FogBank({
     </div>
   );
 }
+
+// The landing hero's grain treatment, shared by the product-page heroes:
+// the film grain over the whole section, fading out toward the bottom so the
+// texture ends with the content instead of cutting at the section edge.
+export function HeroGrain({ id }: { id: string }) {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 -z-10"
+      style={{
+        WebkitMaskImage:
+          "linear-gradient(to bottom, #000 78%, transparent 97%)",
+        maskImage: "linear-gradient(to bottom, #000 78%, transparent 97%)",
+      }}
+    >
+      <FilmGrain id={id} className="opacity-10 mix-blend-screen" />
+    </div>
+  );
+}


### PR DESCRIPTION
Hero / showcase / CTA / footer on both product pages, landing grain and spacing shared via HeroGrain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh