### PR TITLE
fix(marketing): sync HeroGrain with updated landing noise

### DIFF
--- a/apps/web/src/components/marketing/noise-overlay.tsx
+++ b/apps/web/src/components/marketing/noise-overlay.tsx
@@ -32,7 +32,7 @@ export function FilmGrain({
 }
 
 // The fog's cool blue-grey tint, as an feColorMatrix `values` string.
-const TINT_COOL = "0 0 0 0 0.20 0 0 0 0 0.21 0 0 0 0 0.27 0 0 0 0.6 0.04";
+const TINT_COOL = "0 0 0 0 0.20 0 0 0 0 0.21 0 0 0 0 0.23 0 0 0 0.6 0.04";
 
 export function FogBank({
   id,


### PR DESCRIPTION
Top fade + opacity-15, matching the landing hero's tuned treatment on the scan/hud heroes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh