### PR TITLE
feat(marketing): HUD hero sync + bigger modern scan demo

### DIFF
--- a/apps/web/src/app/(marketing)/hud/page.tsx
+++ b/apps/web/src/app/(marketing)/hud/page.tsx
@@ -20,7 +20,7 @@ export default function HudPage() {
   return (
     <div className="flex flex-col gap-36">
       {/* Hero */}
-      <section className="relative isolate w-full overflow-x-clip pt-28">
+      <section className="relative isolate w-full overflow-x-clip pt-28 pb-40">
         <HeroGrain id="hud-noise" />
         <div className="mx-auto w-full max-w-7xl px-5 sm:px-8">
           <p className="text-sm font-medium tracking-wide text-orange-500">
@@ -29,7 +29,7 @@ export default function HudPage() {
           <h1 className="font-display mt-4 max-w-2xl text-4xl font-semibold tracking-tight text-balance md:text-5xl">
             See your agents while you build.
           </h1>
-          <p className="mt-5 max-w-md text-lg text-muted-foreground text-pretty">
+          <p className="mt-5 max-w-lg text-lg text-muted-foreground text-pretty">
             The dashboard watches production. The HUD watches your dev loop:
             every call, tool step and retry, live in the corner of your app.
           </p>

--- a/apps/web/src/app/(marketing)/scan/scan-hero.tsx
+++ b/apps/web/src/app/(marketing)/scan/scan-hero.tsx
@@ -22,7 +22,13 @@ const FlowMap = dynamic(
 // Postgres. Rendered by the same pipeline as a real scan.
 const DEMO_GRAPH: ScanData["graph"] = {
   nodes: [
-    { id: "chat", label: "Chat", kind: "entry", sub: "/api/chat" },
+    {
+      id: "app",
+      label: "Next.js app",
+      kind: "entry",
+      sub: "/api/chat",
+      domain: "nextjs.org",
+    },
     { id: "cron", label: "Daily cron", kind: "cron", sub: "digest, evals" },
     {
       id: "support",
@@ -36,21 +42,19 @@ const DEMO_GRAPH: ScanData["graph"] = {
       kind: "agent",
       sub: "deep dives",
     },
-    { id: "judge", label: "Eval judge", kind: "agent", sub: "scores answers" },
     {
-      id: "claude",
-      label: "Claude Opus 4.8",
+      id: "fable",
+      label: "Claude Fable 5",
       kind: "model",
       domain: "claude.ai",
     },
+    { id: "gpt", label: "GPT-5.5", kind: "model", domain: "openai.com" },
     {
-      id: "gemini",
-      label: "Gemini 3 Pro",
-      kind: "model",
-      domain: "gemini.google.com",
+      id: "firecrawl",
+      label: "Firecrawl",
+      kind: "tool",
+      domain: "firecrawl.dev",
     },
-    { id: "gpt", label: "GPT-5.2", kind: "model", domain: "openai.com" },
-    { id: "firecrawl", label: "Firecrawl", kind: "tool", domain: "firecrawl.dev" },
     { id: "exa", label: "Exa", kind: "tool", domain: "exa.ai" },
     { id: "parallel", label: "Parallel", kind: "tool", domain: "parallel.ai" },
     {
@@ -62,20 +66,18 @@ const DEMO_GRAPH: ScanData["graph"] = {
     },
   ],
   edges: [
-    { from: "chat", to: "support" },
-    { from: "chat", to: "research" },
-    { from: "cron", to: "judge" },
-    { from: "support", to: "claude" },
+    { from: "app", to: "support" },
+    { from: "app", to: "research" },
+    { from: "cron", to: "research" },
+    { from: "support", to: "fable" },
     { from: "support", to: "firecrawl" },
-    { from: "research", to: "gemini" },
+    { from: "research", to: "gpt" },
     { from: "research", to: "exa" },
     { from: "research", to: "parallel" },
-    { from: "judge", to: "gpt" },
     { from: "support", to: "postgres" },
     { from: "research", to: "postgres" },
-    { from: "judge", to: "postgres" },
   ],
-};
+}
 
 export function ScanHero() {
   const reduce = useReducedMotion() ?? false;
@@ -89,7 +91,7 @@ export function ScanHero() {
         };
 
   return (
-    <section className="relative isolate w-full overflow-x-clip pt-28 pb-10">
+    <section className="relative isolate w-full overflow-x-clip pt-28 pb-40">
       {/* Same grain treatment as the landing hero. */}
       <HeroGrain id="scan-hero-noise" />
       <div className="mx-auto flex max-w-7xl items-center justify-between gap-12 px-5 sm:px-8">
@@ -104,15 +106,14 @@ export function ScanHero() {
             {...rise(0.15)}
             className="font-display mt-4 text-4xl font-semibold tracking-tight text-balance md:text-5xl"
           >
-            Map your codebase. Share it.
+            Map your project. Share it.
           </motion.h1>
           <motion.p
             {...rise(0.27)}
-            className="mt-5 max-w-md text-lg text-muted-foreground text-pretty"
+            className="mt-5 max-w-lg text-lg text-muted-foreground text-pretty"
           >
             One prompt turns your repo into a beautiful, interactive map of how
-            it uses AI.{" "}
-            <span className="text-primary">No install, no account.</span>
+            it uses AI. No install, no account.
           </motion.p>
 
           <motion.div
@@ -127,7 +128,7 @@ export function ScanHero() {
         <motion.div
           {...rise(0.5)}
           aria-hidden
-          className="relative hidden h-[440px] min-w-0 flex-1 lg:block"
+          className="relative hidden h-[620px] min-w-0 flex-1 lg:block"
         >
           <FlowMap graph={DEMO_GRAPH} focusKinds={null} embedded />
         </motion.div>

--- a/apps/web/src/components/scan/flow-map.tsx
+++ b/apps/web/src/components/scan/flow-map.tsx
@@ -72,7 +72,7 @@ export function FlowMap({
         height: nodeHeight(n),
       })
     );
-    layoutGraph(sized, folded.edges).then((l) => {
+    layoutGraph(sized, folded.edges, { compact: embedded }).then((l) => {
       if (!cancelled) setLayout(l);
     });
     return () => {
@@ -197,7 +197,9 @@ export function FlowMap({
     const kFit = Math.min(availW / layout.width, availH / layout.height);
     if (kFit >= 0.45) {
       // The whole graph fits at a readable size — center it.
-      const k = clamp(kFit, 0.3, 1);
+      // Embeds may upscale a little — a small demo graph should fill its
+      // marketing slot. The full viewer never upscales (fat borders).
+      const k = clamp(kFit, 0.3, embedded ? 1.35 : 1);
       tRef.current = {
         x: padL + (availW - layout.width * k) / 2,
         y: padY + (availH - layout.height * k) / 2,

--- a/apps/web/src/components/scan/layout.ts
+++ b/apps/web/src/components/scan/layout.ts
@@ -84,7 +84,11 @@ const GROUP_PAD = { top: 46, right: 16, bottom: 16, left: 16 };
 
 export async function layoutGraph<T extends SizedNode>(
   nodes: T[],
-  edges: GraphEdge[]
+  edges: GraphEdge[],
+  opts: {
+    /** Tighter layer gaps for small marketing embeds. */
+    compact?: boolean;
+  } = {}
 ): Promise<Layout<T>> {
   const elk = await getElk();
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
@@ -199,7 +203,11 @@ export async function layoutGraph<T extends SizedNode>(
       "elk.direction": "RIGHT",
       "elk.edgeRouting": "ORTHOGONAL",
       "elk.layered.mergeEdges": "true",
-      "elk.layered.spacing.nodeNodeBetweenLayers": dense ? "110" : "150",
+      "elk.layered.spacing.nodeNodeBetweenLayers": opts.compact
+        ? "80"
+        : dense
+          ? "110"
+          : "150",
       "elk.spacing.nodeNode": dense ? "22" : "32",
       "elk.spacing.edgeNode": dense ? "16" : "24",
       "elk.spacing.edgeEdge": "14",


### PR DESCRIPTION
Mirrors the scan hero updates onto /hud and makes the scan hero's embedded map bigger with a Next.js entry node and Fable 5 / GPT-5.5 models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh