### PR TITLE
fix(scan): interfacecraft-style deck animation

### DIFF
--- a/apps/web/src/app/(marketing)/scan/scan-personalities.tsx
+++ b/apps/web/src/app/(marketing)/scan/scan-personalities.tsx
@@ -10,8 +10,8 @@ import { motion, useReducedMotion } from "motion/react";
 
 import { ARCHETYPES } from "@/components/scan/personality";
 
-// Fan geometry: cards spread along a shallow arc, rotated outward from the
-// center. Order puts the flashiest gradients toward the middle.
+// Scatter geometry, interfacecraft.dev-style: an irregular hand-thrown pile
+// rather than a uniform arc. Rotation and height jitter per card.
 const ORDER = [
   "scheduler",
   "archivist",
@@ -21,6 +21,8 @@ const ORDER = [
   "builder",
   "minimalist",
 ] as const;
+const ROT = [-8, 4, -2, 1, 5, -4, 7];
+const JITTER = [-6, 26, -38, 4, -24, 18, -10];
 
 export function ScanPersonalities() {
   const reduce = useReducedMotion() ?? false;
@@ -42,44 +44,33 @@ export function ScanPersonalities() {
         {ORDER.map((key, i) => {
           const a = ARCHETYPES[key];
           const off = i - mid; // -3 .. 3
-          const rotate = off * 7;
-          const x = off * 118;
-          const y = Math.abs(off) * 26;
+          const rotate = ROT[i]!;
+          const x = off * 128;
+          const y = JITTER[i]!;
           return (
             <motion.div
               key={key}
-              className="absolute left-1/2 top-4"
-              style={{ zIndex: 10 + i }}
+              className="absolute left-1/2 top-10 cursor-pointer select-none"
+              style={{ zIndex: 10 + i, x: "-50%" }}
               initial={
                 reduce
-                  ? { x: "-50%", rotate, translateX: x, y }
-                  : { x: "-50%", rotate: 0, translateX: 0, y: 40, opacity: 0 }
+                  ? { rotate, translateX: x, y }
+                  : { rotate, translateX: x * 0.3, y: y + 90 }
               }
-              whileInView={{
-                x: "-50%",
-                rotate,
-                translateX: x,
-                y,
-                opacity: 1,
-              }}
+              whileInView={{ rotate, translateX: x, y }}
               viewport={{ once: true, amount: 0.5 }}
               transition={{
-                type: "spring",
-                duration: 0.9,
-                bounce: 0.2,
-                delay: reduce ? 0 : 0.15 + i * 0.07,
+                duration: 0.75,
+                ease: [0.22, 1, 0.36, 1],
+                delay: reduce ? 0 : i * 0.04,
               }}
               whileHover={
                 reduce
                   ? undefined
                   : {
-                      y: y - 28,
-                      scale: 1.04,
-                      transition: {
-                        type: "spring",
-                        stiffness: 550,
-                        damping: 34,
-                      },
+                      y: y - 8,
+                      scale: 1.02,
+                      transition: { duration: 0.3, ease: "easeOut" },
                     }
               }
             >


### PR DESCRIPTION
Scatter layout + spread-from-pile entrance + subtle 8px/1.02 hover, matched to transforms sampled from interfacecraft.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh