### PR TITLE
feat(scan): interfacecraft focus-in deck entrance

### DIFF
--- a/apps/web/src/app/(marketing)/scan/scan-personalities.tsx
+++ b/apps/web/src/app/(marketing)/scan/scan-personalities.tsx
@@ -54,22 +54,37 @@ export function ScanPersonalities() {
               initial={
                 reduce
                   ? { rotate, translateX: x, y }
-                  : { rotate, translateX: x * 0.3, y: y + 90 }
+                  : {
+                      rotate,
+                      translateX: x * 0.3,
+                      y: y + 40,
+                      scale: 0.7,
+                      opacity: 0,
+                      filter: "blur(16px)",
+                    }
               }
-              whileInView={{ rotate, translateX: x, y }}
+              whileInView={{
+                rotate,
+                translateX: x,
+                y,
+                scale: 1,
+                opacity: 1,
+                filter: "blur(0px)",
+              }}
               viewport={{ once: true, amount: 0.5 }}
               transition={{
-                duration: 0.5,
-                ease: [0.22, 1, 0.36, 1],
+                duration: 0.7,
+                ease: [0.45, 0, 0.15, 1],
                 delay: reduce ? 0 : i * 0.03,
+                opacity: { duration: 0.35, ease: "easeOut" },
               }}
               whileHover={
                 reduce
                   ? undefined
                   : {
                       y: y - 8,
-                      scale: 1.02,
-                      transition: { duration: 0.16, ease: "easeOut" },
+                      scale: 1.03,
+                      transition: { duration: 0.3, ease: "easeOut" },
                     }
               }
             >


### PR DESCRIPTION
Deck cards now materialize from a blurred, faint, gathered pile and sharpen into the fan (blur 16px -> 0, scale 0.7 -> 1, quick fade), matching the sampled interfacecraft.dev entrance. Hover tuned to the measured values: scale 1.03, 8px lift, 300ms ease-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh