### PR TITLE
fix(scan): softer entrance blur, snappier hover

### DIFF
--- a/apps/web/src/app/(marketing)/scan/scan-personalities.tsx
+++ b/apps/web/src/app/(marketing)/scan/scan-personalities.tsx
@@ -60,7 +60,7 @@ export function ScanPersonalities() {
                       y: y + 40,
                       scale: 0.7,
                       opacity: 0,
-                      filter: "blur(16px)",
+                      filter: "blur(8px)",
                     }
               }
               whileInView={{
@@ -84,7 +84,7 @@ export function ScanPersonalities() {
                   : {
                       y: y - 8,
                       scale: 1.03,
-                      transition: { duration: 0.3, ease: "easeOut" },
+                      transition: { duration: 0.15, ease: "easeOut" },
                     }
               }
             >


### PR DESCRIPTION
Entrance blur halved to 8px; hover lift now 150ms ease-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh