### PR TITLE
fix(scan): deck entrance is pure ease-out

### DIFF
--- a/apps/web/src/app/(marketing)/scan/scan-personalities.tsx
+++ b/apps/web/src/app/(marketing)/scan/scan-personalities.tsx
@@ -74,7 +74,7 @@ export function ScanPersonalities() {
               viewport={{ once: true, amount: 0.5 }}
               transition={{
                 duration: 0.7,
-                ease: [0.45, 0, 0.15, 1],
+                ease: [0.22, 1, 0.36, 1],
                 delay: reduce ? 0 : i * 0.03,
                 opacity: { duration: 0.35, ease: "easeOut" },
               }}


### PR DESCRIPTION
Entrance ease [0.45, 0, 0.15, 1] -> [0.22, 1, 0.36, 1]; no ease-in phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JGWumFVSALEGyu5VncAxh