### PR TITLE
fix(cost): resolve pricing for newer Bedrock creators

### DIFF
--- a/packages/cost/src/cost.test.ts
+++ b/packages/cost/src/cost.test.ts
@@ -99,6 +99,31 @@ describe("normalize", () => {
     // Unparseable bedrock id stays unresolved instead of guessing.
     expect(modelIdCandidates("amazon-bedrock", "mystery-model")).toEqual([]);
   });
+  test("bedrock ids: newer creators (minimax, moonshot, zai, xai, nvidia, google)", () => {
+    expect(modelIdCandidates("amazon-bedrock", "minimax.minimax-m2.5")).toContain(
+      "minimax/minimax-m2.5",
+    );
+    expect(modelIdCandidates("amazon-bedrock", "us.minimax.minimax-m2.5-v1:0")).toContain(
+      "minimax/minimax-m2.5",
+    );
+    // Bedrock ships Kimi under both "moonshot." and "moonshotai."; OpenRouter
+    // uses "moonshotai".
+    expect(modelIdCandidates("amazon-bedrock", "moonshot.kimi-k2-thinking")).toContain(
+      "moonshotai/kimi-k2-thinking",
+    );
+    expect(modelIdCandidates("amazon-bedrock", "moonshotai.kimi-k2.5")).toContain(
+      "moonshotai/kimi-k2.5",
+    );
+    expect(modelIdCandidates("amazon-bedrock", "zai.glm-4.7")).toContain("z-ai/glm-4.7");
+    // xAI gets the dotted-version candidate (OpenRouter says "grok-4.3").
+    expect(modelIdCandidates("amazon-bedrock", "xai.grok-4-3")).toContain("x-ai/grok-4.3");
+    expect(modelIdCandidates("amazon-bedrock", "nvidia.nemotron-nano-9b-v2")).toContain(
+      "nvidia/nemotron-nano-9b-v2",
+    );
+    expect(modelIdCandidates("amazon-bedrock", "google.gemma-3-27b-it")).toContain(
+      "google/gemma-3-27b-it",
+    );
+  });
 });
 
 describe("resolveModelPrice", () => {

--- a/packages/cost/src/normalize.ts
+++ b/packages/cost/src/normalize.ts
@@ -21,6 +21,9 @@ const VENDOR_MAP: Record<string, string> = {
   perplexity: "perplexity",
   meta: "meta-llama",
   amazon: "amazon",
+  // Bedrock creator namespaces whose OpenRouter slug differs.
+  moonshot: "moonshotai",
+  zai: "z-ai",
   groq: "",
   togetherai: "",
   fireworks: "",
@@ -47,7 +50,7 @@ const VERSION_SUFFIX_RE =
 // "apac.", "global.", …), the model's creator, then the model name carrying an
 // ARN-style version suffix — e.g. "us.anthropic.claude-haiku-4-5-20251001-v1:0".
 const BEDROCK_ID_RE =
-  /^(?:[a-z]{2,6}(?:-gov)?\.)?(anthropic|amazon|meta|mistral|cohere|ai21|deepseek|writer|openai|qwen|luma|stability|twelvelabs)\.(.+)$/;
+  /^(?:[a-z]{2,6}(?:-gov)?\.)?(anthropic|amazon|meta|mistral|cohere|ai21|deepseek|writer|openai|qwen|luma|stability|twelvelabs|minimax|google|moonshotai|moonshot|nvidia|xai|zai)\.(.+)$/;
 
 function pushCandidate(out: string[], vendor: string, model: string): void {
   if (!vendor || !model) return;
@@ -57,14 +60,14 @@ function pushCandidate(out: string[], vendor: string, model: string): void {
 }
 
 // Expand one vendor/model pair into ordered lookup candidates: exact first,
-// then date-stripped, then — for Anthropic — the dotted version OpenRouter
-// uses (the Anthropic API says "claude-haiku-4-5", OpenRouter
-// "claude-haiku-4.5").
+// then date-stripped, then — for Anthropic and xAI — the dotted version
+// OpenRouter uses (the Anthropic API says "claude-haiku-4-5", OpenRouter
+// "claude-haiku-4.5"; Bedrock says "grok-4-3", OpenRouter "grok-4.3").
 function expandModel(out: string[], vendor: string, model: string): void {
   pushCandidate(out, vendor, model);
   const dateless = model.replace(VERSION_SUFFIX_RE, "");
   pushCandidate(out, vendor, dateless);
-  if (vendor === "anthropic") {
+  if (vendor === "anthropic" || vendor === "x-ai") {
     pushCandidate(out, vendor, dateless.replace(/(\d)-(\d)/g, "$1.$2"));
   }
 }


### PR DESCRIPTION
A user reported that Bedrock's `minimax.minimax-m2.5` produced no cost. `BEDROCK_ID_RE` hardcodes the creator allowlist and was missing every provider Bedrock has added recently.

## Changes
- Add `minimax`, `google`, `moonshotai`, `moonshot`, `nvidia`, `xai`, `zai` to `BEDROCK_ID_RE` — now covers every provider in the current AWS Bedrock model catalog.
- Map `moonshot → moonshotai` and `zai → z-ai` in `VENDOR_MAP` (Bedrock namespace ≠ OpenRouter slug; Bedrock ships Kimi under both `moonshot.` and `moonshotai.`).
- Extend the dotted-version candidate to xAI (`grok-4-3` → `grok-4.3`).

## Verification
Resolved against the live OpenRouter pricing API: `minimax.minimax-m2.5`, `us.minimax.minimax-m2.5-v1:0`, `moonshot.kimi-k2-thinking`, `moonshotai.kimi-k2.5`, `zai.glm-4.7`, `xai.grok-4-3`, `nvidia.nemotron-nano-9b-v2` all return real prices. Added regression tests; 16 pass.

Note: previously-ingested spans stay uncosted (no repricing pass) — only new traffic gets priced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgWhK1ie24ng6QtcTf5ijr