### PR TITLE
chore(ci): allowlist gustavo-fior in CLA check, fix invalid input name

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,7 +41,7 @@ jobs:
           path-to-signatures: signatures/cla.json
           path-to-document: https://github.com/foglamp-labs/foglamp/blob/master/CLA.md
           branch: cla-signatures
-          custom-notsigned-pryou: "Thanks for your PR! Before we can merge it, please sign the Foglamp CLA by posting the comment below."
+          custom-notsigned-prcomment: "Thanks for your PR! Before we can merge it, please sign the Foglamp CLA by posting the comment below."
           custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
           custom-allsigned-prcomment: "All contributors have signed the CLA. ✅"
-          allowlist: dependabot[bot],github-actions[bot]
+          allowlist: gustavo-fior,dependabot[bot],github-actions[bot]


### PR DESCRIPTION
Adds the repo owner to the CLA allowlist and renames the invalid `custom-notsigned-pryou` input to `custom-notsigned-prcomment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgWhK1ie24ng6QtcTf5ijr