### PR TITLE
chore(web): landing page spacing and visual polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ temp
 
 # foglamp poster output (generated)
 .foglamp/
+.vercel
+.env*

--- a/apps/web/src/app/(marketing)/hud/page.tsx
+++ b/apps/web/src/app/(marketing)/hud/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { HudPlayground } from "@/components/marketing/hud/hud-playground";
 import { CtaSection } from "@/components/marketing/landing/cta";
 import { HeroGrain } from "@/components/marketing/noise-overlay";
+import { IconDirectionArrowsFilled } from "@tabler/icons-react";
 
 export const metadata: Metadata = {
   title: "HUD",
@@ -23,8 +24,9 @@ export default function HudPage() {
       <section className="relative isolate w-full overflow-x-clip pt-28 pb-40">
         <HeroGrain id="hud-noise" />
         <div className="mx-auto w-full max-w-7xl px-5 sm:px-8">
-          <p className="text-sm font-medium tracking-wide text-orange-500">
-            Foglamp HUD
+          <p className="text-base font-medium tracking-wide text-orange-500 flex gap-1.5 items-center">
+            <IconDirectionArrowsFilled className="size-4" />
+            HUD
           </p>
           <h1 className="font-display mt-4 max-w-2xl text-4xl font-semibold tracking-tight text-balance md:text-5xl">
             See your agents while you build.
@@ -52,8 +54,8 @@ export default function HudPage() {
               Zero setup
             </h3>
             <p className="mt-2 text-sm text-muted-foreground text-pretty">
-              It ships inside the SDK. When your agent wires Foglamp up, the
-              HUD comes with it. Nothing to install, nothing to deploy.
+              It ships inside the SDK. When your agent wires Foglamp up, the HUD
+              comes with it. Nothing to install, nothing to deploy.
             </p>
           </div>
           <div>
@@ -61,8 +63,8 @@ export default function HudPage() {
               Local by default
             </h3>
             <p className="mt-2 text-sm text-muted-foreground text-pretty">
-              Traces stream to the overlay on your machine. No API key, no
-              data leaves your laptop. It turns itself off in production.
+              Traces stream to the overlay on your machine. No API key, no data
+              leaves your laptop. It turns itself off in production.
             </p>
           </div>
           <div>
@@ -70,8 +72,8 @@ export default function HudPage() {
               The full story
             </h3>
             <p className="mt-2 text-sm text-muted-foreground text-pretty">
-              Timeline, tool calls, retries, cost per run. When something
-              fails you watch it fail, instead of digging through logs.
+              Timeline, tool calls, retries, cost per run. When something fails
+              you watch it fail, instead of digging through logs.
             </p>
           </div>
         </div>

--- a/apps/web/src/app/(marketing)/scan/copy-scan-prompt-button.tsx
+++ b/apps/web/src/app/(marketing)/scan/copy-scan-prompt-button.tsx
@@ -66,12 +66,12 @@ export function CopyScanPromptButton({ className }: { className?: string }) {
         }}
         aria-label="Copy the scan prompt"
       >
-        Copy scan prompt
         <CopyIcon
           copied={copied}
-          className="size-4 mt-px"
+          className="size-4"
           checkClassName="size-4 text-green-600 mt-px"
         />
+        Copy scan prompt
       </Button>
     </BorderBeam>
   );

--- a/apps/web/src/components/marketing/footer.tsx
+++ b/apps/web/src/components/marketing/footer.tsx
@@ -88,7 +88,7 @@ export function MarketingFooter() {
           </filter>
         </svg>
       </figure>
-      <div className="mx-auto max-w-7xl px-5 py-16 pb-28 sm:px-8">
+      <div className="mx-auto max-w-7xl px-5 py-20 pb-28 sm:px-8">
         {/* Trailing 1fr is a ghost column that keeps the link columns pulled
             toward the brand instead of spread across the full width. */}
         <div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-[1.5fr_1fr_1fr_1fr]">

--- a/apps/web/src/components/marketing/landing/cta.tsx
+++ b/apps/web/src/components/marketing/landing/cta.tsx
@@ -23,7 +23,7 @@ export function CtaSection() {
   return (
     <section
       ref={ref}
-      className="relative isolate flex w-full flex-col justify-center overflow-hidden py-32 sm:py-44 mb-12"
+      className="relative isolate flex w-full flex-col justify-center overflow-hidden mb-20"
       style={{ minHeight: "780px" }}
     >
       {/* Faint dashboard grid so the fog has a surface to sit on. */}
@@ -64,7 +64,7 @@ export function CtaSection() {
           }}
         >
           <div
-            className="fog-layer absolute inset-[-15%] opacity-3"
+            className="fog-layer absolute inset-[-15%] opacity-30"
             style={{
               filter: "blur(4px)",
               animationName: "fog-drift-a",
@@ -107,7 +107,7 @@ export function CtaSection() {
           </div>
           {/* bottom-right filler */}
           <div
-            className="fog-layer absolute inset-[-15%] opacity-35"
+            className="fog-layer absolute inset-[-15%] opacity-45"
             style={{
               filter: "blur(18px)",
               animationName: "fog-drift-d",
@@ -123,7 +123,7 @@ export function CtaSection() {
           {/* a denser puff right on top of the agent details, so they read as
               half-swallowed by the fog */}
           <div
-            className="fog-layer absolute inset-[-15%] opacity-60"
+            className="fog-layer absolute inset-[-15%] opacity-40"
             style={{
               filter: "blur(12px)",
               animationName: "fog-drift-e",

--- a/apps/web/src/components/marketing/landing/drift-story.tsx
+++ b/apps/web/src/components/marketing/landing/drift-story.tsx
@@ -144,7 +144,7 @@ export function DriftStory() {
         };
 
   return (
-    <section className="mx-auto w-full max-w-7xl px-5 sm:px-8">
+    <section className="mx-auto w-full max-w-7xl px-5 sm:px-8 mt-32">
       <div className="relative isolate overflow-hidden rounded-[64px] corner-squircle bg-card dark:bg-card/50 shadow-(--custom-shadow) px-2 py-3 sm:px-12 sm:py-24">
         {/* Subtle film-grain texture over the card. feTurbulence fills the
             filter region with noise, grayscale strips its color, and

--- a/apps/web/src/components/marketing/landing/hero.tsx
+++ b/apps/web/src/components/marketing/landing/hero.tsx
@@ -66,7 +66,7 @@ const TRUSTED: { label: string; node: React.ReactNode }[] = [
     label: "Option",
     node: (
       <span className="flex items-center gap-2">
-        <OptionLogo className="size-3.5 text-[#878787]" />
+        <OptionLogo className="size-3.5 text-[#676767]" />
         <span className="text-lg font-semibold tracking-normal">Option</span>
       </span>
     ),
@@ -188,12 +188,11 @@ export function Hero() {
         aria-hidden
         className="pointer-events-none absolute inset-0 -z-10"
         style={{
-          WebkitMaskImage:
-            "linear-gradient(to bottom, #000 78%, transparent 97%)",
-          maskImage: "linear-gradient(to bottom, #000 78%, transparent 97%)",
+          WebkitMaskImage: "linear-gradient(to top, #000 78%, transparent 97%)",
+          maskImage: "linear-gradient(to top, #000 78%, transparent 97%)",
         }}
       >
-        <FilmGrain id="hero-noise" className="opacity-10 mix-blend-screen" />
+        <FilmGrain id="hero-noise" className="opacity-15 mix-blend-screen" />
       </div>
 
       {/* Copy: left-aligned, sharing the dashboard's max-w-7xl left edge. */}
@@ -209,10 +208,8 @@ export function Hero() {
             {...rise(0.27)}
             className="mt-5 max-w-md text-lg text-muted-foreground text-pretty"
           >
-            See the cost, latency, and quality of every LLM call.{" "}
-            <span className="text-primary">
-              Catch bad output before your users do.
-            </span>
+            See the cost, latency, and quality of every LLM call. Catch bad
+            output before your users do.
           </motion.p>
 
           <div className="mt-8 flex flex-wrap items-center gap-3">
@@ -271,7 +268,7 @@ export function Hero() {
           hero's grain. Real projects running on Foglamp, all monochrome. */}
       <motion.div
         {...rise(1.7)}
-        className="mx-auto mt-18 flex w-full max-w-7xl flex-wrap items-center gap-x-20 gap-y-5 px-5 sm:px-8"
+        className="mx-auto mt-18 flex w-full max-w-7xl flex-wrap items-center gap-x-20 gap-y-5 px-5 sm:px-8 pb-18"
       >
         <p className="text-sm text-muted-foreground/50">Trusted by</p>
         <ul className="contents list-none">
@@ -279,7 +276,7 @@ export function Hero() {
             <li
               key={label}
               title={label}
-              className="text-muted-foreground/70 grayscale"
+              className="text-muted-foreground/60 grayscale"
             >
               {node}
             </li>

--- a/apps/web/src/components/marketing/landing/how-it-works.tsx
+++ b/apps/web/src/components/marketing/landing/how-it-works.tsx
@@ -298,7 +298,7 @@ const STEPS = [
 
 export function HowItWorks() {
   return (
-    <section className="mx-auto w-full max-w-7xl px-5 sm:px-8 -mb-24">
+    <section className="mx-auto w-full max-w-7xl px-5 sm:px-8 mt-52 mb-32">
       <h2 className="font-display text-3xl font-semibold tracking-tight text-balance sm:text-4xl">
         Set up in one prompt.
       </h2>
@@ -306,14 +306,14 @@ export function HowItWorks() {
         Just hand it to Claude Code or Codex and get going.
       </p>
 
-      <div className="mt-16 grid gap-12 md:grid-cols-3 md:gap-20">
+      <div className="mt-20 grid gap-12 md:grid-cols-3 md:gap-20">
         {STEPS.map((step) => (
           <div key={step.n}>
             {/* arts sit a little narrower than the text column */}
             <div className="w-11/12">
               <step.Art />
             </div>
-            <h3 className="mt-5 font-display text-lg font-semibold tracking-tight">
+            <h3 className="mt-8 font-display text-lg font-semibold tracking-tight">
               <span className="mr-2 text-muted-foreground/60">{step.n}</span>
               {step.title}
             </h3>

--- a/apps/web/src/components/marketing/landing/landing-page.tsx
+++ b/apps/web/src/components/marketing/landing/landing-page.tsx
@@ -57,7 +57,7 @@ const homepageJsonLd = {
 export function LandingPage() {
   return (
     // No bottom padding: the CTA runs straight into the footer.
-    <div className="flex flex-col gap-36">
+    <div className="flex flex-col">
       <JsonLd data={homepageJsonLd} />
       <Hero />
       <DriftStory />

--- a/apps/web/src/components/marketing/navbar.tsx
+++ b/apps/web/src/components/marketing/navbar.tsx
@@ -61,13 +61,13 @@ function ProductsMenu() {
             <li key={item.href}>
               <NavigationMenuLink
                 render={<Link href={item.href} />}
-                className="flex-col items-start gap-0.5 px-3 py-2.5"
+                className="flex-col items-start gap-1 px-3 py-2.5"
               >
-                <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1.5 font-medium">
                   <item.Icon className="size-3.5" />
                   {item.name}
                 </span>
-                <span className="font-medium text-foreground">
+                <span className=" text-muted-foreground text-xs">
                   {item.pitch}
                 </span>
               </NavigationMenuLink>


### PR DESCRIPTION
Marketing-site polish pass: per-section landing spacing (replaces the global `gap-36`), hero grain/subheadline tweaks, CTA fog opacity rebalance, navbar products-menu hierarchy swap, HUD eyebrow icon, scan copy-button icon placement, plus `.vercel`/`.env*` in .gitignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PgWhK1ie24ng6QtcTf5ijr