### PR TITLE
Improve agent/GEO readiness: markdown negotiation, JSON errors, helpful 404s

### DIFF
--- a/apps/ingest/src/httpErrors.test.ts
+++ b/apps/ingest/src/httpErrors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+import { errorResponse, notFoundResponse } from "./httpErrors";
+
+function makeApp() {
+  const app = new Hono();
+  app.get("/ok", (c) => c.text("ok"));
+  app.get("/boom", () => {
+    throw new Error("kaboom");
+  });
+  app.get("/teapot", () => {
+    throw new HTTPException(418, { message: "short and stout" });
+  });
+  app.notFound(notFoundResponse);
+  app.onError(errorResponse);
+  return app;
+}
+
+describe("notFoundResponse", () => {
+  test("unmatched routes return structured JSON with a 404", async () => {
+    const res = await makeApp().request("/nope/nothing-here");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = (await res.json()) as { error: string; code: string; hint?: string };
+    expect(body.code).toBe("not_found");
+    expect(body.error).toContain("GET /nope/nothing-here");
+    expect(body.hint).toContain("docs.foglamp.dev");
+  });
+
+  test("matched routes are untouched", async () => {
+    const res = await makeApp().request("/ok");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+});
+
+describe("errorResponse", () => {
+  test("uncaught errors become a JSON 500 without leaking the message", async () => {
+    const res = await makeApp().request("/boom");
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; code: string; hint?: string };
+    expect(body.code).toBe("internal_error");
+    expect(JSON.stringify(body)).not.toContain("kaboom");
+    expect(body.hint).toBeString();
+  });
+
+  test("HTTPException keeps its status and message as JSON", async () => {
+    const res = await makeApp().request("/teapot");
+    expect(res.status).toBe(418);
+    const body = (await res.json()) as { error: string; code: string; hint?: string };
+    expect(body.error).toBe("short and stout");
+    expect(body.code).toBe("http_error");
+  });
+});

--- a/apps/ingest/src/httpErrors.ts
+++ b/apps/ingest/src/httpErrors.ts
@@ -1,0 +1,44 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+// Fallback error surface for the API. Every route already returns flat
+// `{ error: string }` bodies on failure; unmatched paths and uncaught throws
+// used to fall through to Hono's plain-text defaults ("404 Not Found"), which
+// coding agents can't parse. These handlers keep the same `error` key and add
+// `code` + `hint` so an agent that lands here knows what happened and where to
+// go next.
+
+const DOCS_URL = "https://docs.foglamp.dev";
+
+export function notFoundResponse(c: Context): Response {
+  return c.json(
+    {
+      error: `No route for ${c.req.method} ${c.req.path}`,
+      code: "not_found",
+      hint: `Check the API reference at ${DOCS_URL}/api-reference/introduction or the docs index at ${DOCS_URL}/llms.txt.`,
+    },
+    404,
+  );
+}
+
+export function errorResponse(err: Error, c: Context): Response {
+  // Routes that throw HTTPException chose their status (and sometimes a
+  // Response) deliberately — pass their body through untouched when it's
+  // already JSON, otherwise wrap the message in the standard shape.
+  if (err instanceof HTTPException) {
+    const res = err.getResponse();
+    if (res.headers.get("content-type")?.includes("json")) return res;
+    return c.json(
+      { error: err.message || "Request failed", code: "http_error" },
+      err.status,
+    );
+  }
+  return c.json(
+    {
+      error: "Internal server error",
+      code: "internal_error",
+      hint: "Retry the request; if it keeps failing, report it at https://github.com/foglamp-labs/foglamp/issues.",
+    },
+    500,
+  );
+}

--- a/apps/ingest/src/main.ts
+++ b/apps/ingest/src/main.ts
@@ -17,6 +17,7 @@ import { pruneApiKeyCache, resolveApiKey } from "./apiKey";
 import { WriteBuffer } from "./buffer";
 import { getProjectPricing, pruneCustomPricing } from "./customPricing";
 import { evlog, type AppEnv } from "./evlog";
+import { errorResponse, notFoundResponse } from "./httpErrors";
 import { checkOrgQuota, pruneOrgLimits } from "./orgLimits";
 import { checkRateLimit, pruneRateLimits } from "./rateLimit";
 import { buildCustomerRows, buildSpanRows } from "./transform";
@@ -202,6 +203,11 @@ app.post("/v1/traces", (c) =>
 );
 
 app.get("/", (c) => c.text("foglamp ingest"));
+
+// Agent-friendly fallbacks: JSON (not plain text) for unmatched routes and
+// uncaught errors, with a machine-readable code and a where-to-look hint.
+app.notFound(notFoundResponse);
+app.onError(errorResponse);
 
 // --- Graceful shutdown: flush the volatile buffer before exiting ----------
 let shuttingDown = false;

--- a/apps/server/src/httpErrors.test.ts
+++ b/apps/server/src/httpErrors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+import { errorResponse, notFoundResponse } from "./httpErrors";
+
+function makeApp() {
+  const app = new Hono();
+  app.get("/ok", (c) => c.text("ok"));
+  app.get("/boom", () => {
+    throw new Error("kaboom");
+  });
+  app.get("/teapot", () => {
+    throw new HTTPException(418, { message: "short and stout" });
+  });
+  app.notFound(notFoundResponse);
+  app.onError(errorResponse);
+  return app;
+}
+
+describe("notFoundResponse", () => {
+  test("unmatched routes return structured JSON with a 404", async () => {
+    const res = await makeApp().request("/nope/nothing-here");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = (await res.json()) as { error: string; code: string; hint?: string };
+    expect(body.code).toBe("not_found");
+    expect(body.error).toContain("GET /nope/nothing-here");
+    expect(body.hint).toContain("docs.foglamp.dev");
+  });
+
+  test("matched routes are untouched", async () => {
+    const res = await makeApp().request("/ok");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+});
+
+describe("errorResponse", () => {
+  test("uncaught errors become a JSON 500 without leaking the message", async () => {
+    const res = await makeApp().request("/boom");
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; code: string; hint?: string };
+    expect(body.code).toBe("internal_error");
+    expect(JSON.stringify(body)).not.toContain("kaboom");
+    expect(body.hint).toBeString();
+  });
+
+  test("HTTPException keeps its status and message as JSON", async () => {
+    const res = await makeApp().request("/teapot");
+    expect(res.status).toBe(418);
+    const body = (await res.json()) as { error: string; code: string; hint?: string };
+    expect(body.error).toBe("short and stout");
+    expect(body.code).toBe("http_error");
+  });
+});

--- a/apps/server/src/httpErrors.ts
+++ b/apps/server/src/httpErrors.ts
@@ -1,0 +1,44 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+// Fallback error surface for the API. Every route already returns flat
+// `{ error: string }` bodies on failure; unmatched paths and uncaught throws
+// used to fall through to Hono's plain-text defaults ("404 Not Found"), which
+// coding agents can't parse. These handlers keep the same `error` key and add
+// `code` + `hint` so an agent that lands here knows what happened and where to
+// go next.
+
+const DOCS_URL = "https://docs.foglamp.dev";
+
+export function notFoundResponse(c: Context): Response {
+  return c.json(
+    {
+      error: `No route for ${c.req.method} ${c.req.path}`,
+      code: "not_found",
+      hint: `Check the API reference at ${DOCS_URL}/api-reference/introduction or the docs index at ${DOCS_URL}/llms.txt.`,
+    },
+    404,
+  );
+}
+
+export function errorResponse(err: Error, c: Context): Response {
+  // Routes that throw HTTPException chose their status (and sometimes a
+  // Response) deliberately — pass their body through untouched when it's
+  // already JSON, otherwise wrap the message in the standard shape.
+  if (err instanceof HTTPException) {
+    const res = err.getResponse();
+    if (res.headers.get("content-type")?.includes("json")) return res;
+    return c.json(
+      { error: err.message || "Request failed", code: "http_error" },
+      err.status,
+    );
+  }
+  return c.json(
+    {
+      error: "Internal server error",
+      code: "internal_error",
+      hint: "Retry the request; if it keeps failing, report it at https://github.com/foglamp-labs/foglamp/issues.",
+    },
+    500,
+  );
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -20,6 +20,7 @@ import { cors } from "hono/cors";
 
 import { requireApiKey } from "./apiKeyAuth";
 import { evlog, type AppEnv } from "./evlog";
+import { errorResponse, notFoundResponse } from "./httpErrors";
 import {
   handleFoggy,
   handleFoggyThreadGet,
@@ -171,6 +172,11 @@ app.post("/instrumentation-plans/:id/failed", requireApiKey, handlePlanFailed);
 app.get("/", (c) => {
   return c.text("OK");
 });
+
+// Agent-friendly fallbacks: JSON (not plain text) for unmatched routes and
+// uncaught errors, with a machine-readable code and a where-to-look hint.
+app.notFound(notFoundResponse);
+app.onError(errorResponse);
 
 // Alert evaluator: sweep enabled rules on an interval, transition state, and
 // email on fired/resolved. apps/server is the long-running tier that owns it.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -11,10 +11,29 @@ const nextConfig: NextConfig = {
     // all client-side tRPC anyway, and those queries revalidate on mount.
     staleTimes: { dynamic: 30 },
   },
-  // The scan product used to live at /poster.
+  // The scan product used to live at /poster. /openapi.json gives agents a
+  // predictable, name-guessable URL for the API spec (canonical copy lives on
+  // the docs site so it can't drift from the API reference).
   redirects: async () => [
     { source: "/poster", destination: "/scan", permanent: true },
     { source: "/poster/:slug*", destination: "/scan/:slug*", permanent: true },
+    {
+      source: "/openapi.json",
+      destination: "https://docs.foglamp.dev/api-reference/openapi.json",
+      permanent: false,
+    },
+  ],
+  // The marketing pages are content-negotiated (HTML ⇄ text/markdown, see
+  // proxy.ts). Their HTML variant must also carry `Vary: Accept` so shared
+  // caches never hand the HTML to an agent that asked for markdown (or vice
+  // versa). Set here because Next replaces Vary values set from the proxy on
+  // page responses; the router merges this one into its own Vary list.
+  headers: async () => [
+    {
+      source:
+        "/(|homepage|pricing|about|privacy|terms|features/cost-intelligence|features/evals|features/alerts|features/agents|features/distributed-traces|features/sdk)",
+      headers: [{ key: "Vary", value: "Accept" }],
+    },
   ],
   images: {
     remotePatterns: [

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -32,9 +32,17 @@ const BODY = `# Foglamp
 - [Alerts](${SITE_URL}/features/alerts): threshold rules on cost, latency, and error rate.
 - [SDK](${SITE_URL}/features/sdk): two lines instrument every generateText / streamText call.
 
-## Reference
-- [API reference (OpenAPI)](${DOCS_ORIGIN}/api-reference/openapi.json): machine-readable API specification.
-- [Source code](${GITHUB_URL}): GitHub repository (Apache 2.0).
+## Foglamp developer resources
+- [Foglamp API reference](${DOCS_ORIGIN}/api-reference/introduction): the ingest API, authentication, and error shapes.
+- [Foglamp OpenAPI spec](${DOCS_ORIGIN}/api-reference/openapi.json): machine-readable API specification (also at ${SITE_URL}/openapi.json).
+- [Foglamp changelog](${DOCS_ORIGIN}/changelog): what shipped, release by release.
+- [Foglamp source code](${GITHUB_URL}): GitHub repository (Apache 2.0, self-hostable).
+
+## Notes for agents
+- Every marketing page on ${SITE_URL} is also served as markdown: request it
+  with \`Accept: text/markdown\`, or append \`.md\` to the path (e.g.
+  ${SITE_URL}/pricing.md).
+- Nonexistent paths return a real 404 with a markdown body pointing back here.
 `;
 
 export function GET() {

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { DOCS_ORIGIN } from "@/lib/links";
+
+export const metadata: Metadata = {
+	title: "Page not found",
+};
+
+// Global 404. Rendered with a real 404 status; the body doubles as a recovery
+// map for agents and crawlers (home, docs, llms.txt, sitemap) instead of a
+// bare app shell. Agents that ask for `Accept: text/markdown` get the markdown
+// equivalent straight from proxy.ts and never reach this component.
+export default function NotFound() {
+	const links = [
+		{ label: "Homepage", href: "/" },
+		{ label: "Pricing", href: "/pricing" },
+		{ label: "Documentation", href: DOCS_ORIGIN, external: true },
+		{ label: "llms.txt (site index for LLMs)", href: "/llms.txt" },
+		{ label: "sitemap.xml", href: "/sitemap.xml" },
+	];
+
+	return (
+		<div className="flex min-h-svh flex-col items-center justify-center bg-background px-6 py-24">
+			<p className="font-mono text-sm text-muted-foreground">404</p>
+			<h1 className="mt-3 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+				Page not found
+			</h1>
+			<p className="mt-3 max-w-md text-center text-balance text-muted-foreground">
+				There&apos;s no page at this address. Here&apos;s where to look
+				instead:
+			</p>
+			<ul className="mt-8 flex flex-col items-center gap-2">
+				{links.map((l) => (
+					<li key={l.href}>
+						{l.external ? (
+							<a
+								href={l.href}
+								className="text-sm font-medium text-foreground underline underline-offset-4 hover:text-muted-foreground"
+							>
+								{l.label}
+							</a>
+						) : (
+							<Link
+								href={l.href as "/"}
+								className="text-sm font-medium text-foreground underline underline-offset-4 hover:text-muted-foreground"
+							>
+								{l.label}
+							</Link>
+						)}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Route } from "next";
 import Link from "next/link";
 
 import { DOCS_ORIGIN } from "@/lib/links";
@@ -42,7 +42,7 @@ export default function NotFound() {
 							</a>
 						) : (
 							<Link
-								href={l.href as "/"}
+								href={l.href as Route}
 								className="text-sm font-medium text-foreground underline underline-offset-4 hover:text-muted-foreground"
 							>
 								{l.label}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -11,6 +11,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 		{ path: "", priority: 1 },
 		{ path: "/pricing", priority: 0.9 },
 		...products.map((p) => ({ path: p.href as string, priority: 0.8 })),
+		{ path: "/about", priority: 0.5 },
 		{ path: "/privacy", priority: 0.3 },
 		{ path: "/terms", priority: 0.3 },
 	];

--- a/apps/web/src/components/marketing/landing/drift-story.tsx
+++ b/apps/web/src/components/marketing/landing/drift-story.tsx
@@ -144,7 +144,17 @@ export function DriftStory() {
 				};
 
 	return (
-		<section className="mx-auto w-full max-w-7xl px-5 sm:px-8 mt-32">
+		<section
+			aria-labelledby="drift-story-heading"
+			className="mx-auto w-full max-w-7xl px-5 sm:px-8 mt-32"
+		>
+			{/* The section's story is told visually (timeline + complaint pings);
+          this heading gives it a place in the document outline for crawlers
+          and screen readers without changing the design. */}
+			<h2 id="drift-story-heading" className="sr-only">
+				Without observability, AI quality drifts silently — and customers
+				notice before you do
+			</h2>
 			<div className="relative isolate overflow-hidden rounded-3xl squircle:rounded-[64px] corner-squircle bg-card dark:bg-card/50 shadow-(--custom-shadow) px-2 py-3 sm:px-12 sm:py-24">
 				{/* Subtle film-grain texture over the card. feTurbulence fills the
             filter region with noise, grayscale strips its color, and

--- a/apps/web/src/lib/accept.test.ts
+++ b/apps/web/src/lib/accept.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import { negotiateFormat } from "./accept";
+
+describe("negotiateFormat", () => {
+	test("no header defaults to html", () => {
+		expect(negotiateFormat(null)).toBe("html");
+		expect(negotiateFormat("")).toBe("html");
+		expect(negotiateFormat("   ")).toBe("html");
+	});
+
+	test("plain markdown request gets markdown", () => {
+		expect(negotiateFormat("text/markdown")).toBe("markdown");
+	});
+
+	test("browser-style header gets html", () => {
+		expect(
+			negotiateFormat(
+				"text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+			),
+		).toBe("html");
+	});
+
+	test("wildcard alone gets html", () => {
+		expect(negotiateFormat("*/*")).toBe("html");
+	});
+
+	test("q-values are honored: markdown preferred over html", () => {
+		expect(negotiateFormat("text/html;q=0.5, text/markdown")).toBe("markdown");
+		expect(negotiateFormat("text/markdown;q=0.9, text/html;q=0.3")).toBe(
+			"markdown",
+		);
+	});
+
+	test("q-values are honored: html preferred over markdown", () => {
+		expect(negotiateFormat("text/markdown;q=0.2, text/html")).toBe("html");
+	});
+
+	test("ties go to html", () => {
+		expect(negotiateFormat("text/markdown, text/html")).toBe("html");
+	});
+
+	test("specific match beats a range", () => {
+		// */* covers html at q=1, but the explicit markdown entry is more
+		// specific for markdown while html only matches the wildcard — html
+		// still wins the tie at q=1.
+		expect(negotiateFormat("text/markdown;q=0.5, */*")).toBe("html");
+		// Here html is explicitly downranked below the markdown match.
+		expect(negotiateFormat("text/markdown, text/html;q=0.4, */*;q=0.1")).toBe(
+			"markdown",
+		);
+	});
+
+	test("q=0 excludes a type", () => {
+		expect(negotiateFormat("text/html;q=0, text/markdown")).toBe("markdown");
+	});
+
+	test("unsupported types alone are unacceptable", () => {
+		expect(negotiateFormat("application/json")).toBe("unacceptable");
+		expect(negotiateFormat("image/png, application/pdf")).toBe("unacceptable");
+	});
+
+	test("text/* range covers both, html wins", () => {
+		expect(negotiateFormat("text/*")).toBe("html");
+	});
+
+	test("malformed header falls back to html", () => {
+		expect(negotiateFormat("garbage")).toBe("html");
+	});
+});

--- a/apps/web/src/lib/accept.ts
+++ b/apps/web/src/lib/accept.ts
@@ -1,0 +1,69 @@
+// Minimal Accept-header negotiation between the two representations the
+// marketing site serves: text/html (default) and text/markdown (for agents,
+// per acceptmarkdown.com). Honors q-values per RFC 9110 §12.5.1 — more
+// specific matches (text/markdown) beat ranges (text/*, */*), and a q of 0
+// means "explicitly not acceptable".
+
+export type NegotiatedFormat = "html" | "markdown" | "unacceptable";
+
+type Entry = { type: string; subtype: string; q: number };
+
+function parseAccept(header: string): Entry[] {
+	const entries: Entry[] = [];
+	for (const part of header.split(",")) {
+		const [range, ...params] = part.trim().split(";");
+		if (!range) continue;
+		const [type, subtype] = range.trim().toLowerCase().split("/");
+		if (!type || !subtype) continue;
+		let q = 1;
+		for (const param of params) {
+			const [key, value] = param.trim().split("=");
+			if (key?.trim() === "q" && value !== undefined) {
+				const parsed = Number.parseFloat(value);
+				if (!Number.isNaN(parsed)) q = Math.min(1, Math.max(0, parsed));
+			}
+		}
+		entries.push({ type, subtype, q });
+	}
+	return entries;
+}
+
+// Quality for a concrete media type: the q of the most specific matching
+// entry (exact beats text/* beats */*). Undefined when nothing matches.
+function quality(
+	entries: Entry[],
+	type: string,
+	subtype: string,
+): number | undefined {
+	let best: { specificity: number; q: number } | undefined;
+	for (const e of entries) {
+		let specificity: number;
+		if (e.type === type && e.subtype === subtype) specificity = 2;
+		else if (e.type === type && e.subtype === "*") specificity = 1;
+		else if (e.type === "*" && e.subtype === "*") specificity = 0;
+		else continue;
+		if (!best || specificity > best.specificity) best = { specificity, q: e.q };
+	}
+	return best?.q;
+}
+
+/**
+ * Pick the representation for a request. No/empty/malformed Accept header
+ * falls back to HTML (browsers always send one; lenient beats a 406 for
+ * sloppy agents). Markdown wins only when the client q-prefers it strictly
+ * over HTML — ties go to HTML, matching what browsers expect.
+ */
+export function negotiateFormat(header: string | null): NegotiatedFormat {
+	if (!header || !header.trim()) return "html";
+	const entries = parseAccept(header);
+	if (entries.length === 0) return "html";
+
+	const html = quality(entries, "text", "html") ?? 0;
+	const markdown = quality(entries, "text", "markdown") ?? 0;
+
+	if (markdown > 0 && markdown > html) return "markdown";
+	if (html > 0) return "html";
+	// Neither acceptable: anything with a positive */* or text/* was already
+	// counted above, so this Accept header genuinely excludes both.
+	return "unacceptable";
+}

--- a/apps/web/src/lib/markdown-pages.ts
+++ b/apps/web/src/lib/markdown-pages.ts
@@ -1,0 +1,169 @@
+import { DOCS_ORIGIN, GITHUB_URL, SITE_URL } from "@/lib/links";
+
+// Markdown representations of the marketing pages, served to agents via
+// `Accept: text/markdown` content negotiation (acceptmarkdown.com) and at the
+// `<path>.md` aliases — see proxy.ts. Hand-written mirrors of the React pages:
+// keep the facts (taglines, plan limits, links) in sync when those change.
+// The full documentation already has auto-generated .md mirrors on
+// docs.foglamp.dev; this covers the marketing surface on foglamp.dev itself.
+
+const FOOTER = `
+
+---
+
+- Docs: ${DOCS_ORIGIN} (markdown mirrors at \`<page>.md\`, index at ${DOCS_ORIGIN}/llms.txt)
+- LLM index for this site: ${SITE_URL}/llms.txt
+- OpenAPI spec (ingest API): ${DOCS_ORIGIN}/api-reference/openapi.json
+- Source: ${GITHUB_URL} (Apache-2.0, self-hostable)`;
+
+const HOME = `# Foglamp — Observability for AI agents
+
+> The missing observability layer for the Vercel AI SDK. Two lines of code and
+> an API key give you costs, latency, token usage, distributed traces, evals,
+> and alerts for every generateText / streamText call — across every model your
+> AI agents use. Open source (Apache 2.0) and self-hostable.
+
+## What you get
+
+- **Cost intelligence** (${SITE_URL}/features/cost-intelligence): know exactly what every call costs, by model, agent, customer.
+- **Distributed traces** (${SITE_URL}/features/distributed-traces): waterfall every run, with the exact prompt and response per span.
+- **Evals** (${SITE_URL}/features/evals): score production traffic with code checks and LLM judges.
+- **Alerts** (${SITE_URL}/features/alerts): threshold rules on cost, latency, and error rate.
+- **Agents** (${SITE_URL}/features/agents): per-agent spans, latency, and spend — with the full call flow.
+- **SDK** (${SITE_URL}/features/sdk): two lines instruments every generateText / streamText call.
+
+## Get started
+
+1. Quickstart: ${DOCS_ORIGIN}/quickstart
+2. Agent-oriented setup guide (paste into your coding agent): ${DOCS_ORIGIN}/ai-instrument.md
+3. Pricing (Free / Pro $49/mo / Enterprise): ${SITE_URL}/pricing`;
+
+const PRICING = `# Foglamp pricing
+
+Usage-based plans for AI observability. All plans include unlimited agents,
+workflows, traces & sessions, and team members.
+
+| Plan | Price | Spans / month | Retention | Projects | Alerts | Evals |
+| --- | --- | --- | --- | --- | --- | --- |
+| Free | $0 forever | 10,000 | 3 days | 1 | 1 | 5 |
+| Pro | $49 / month | 1,000,000 | 14 days | 5 | 10 | 20 |
+| Enterprise | Custom | Custom | 90+ days | Custom | Custom | Custom |
+
+- **Free** — everything you need to instrument your first agent. Sign up: ${SITE_URL}/login
+- **Pro** — production-grade observability for growing teams. Adds the Foggy AI assistant, email & Slack alerting, and priority support.
+- **Enterprise** — custom limits and controls for scale. Adds SSO/SAML, audit logs, dedicated support & SLA. Contact: sales@foglamp.dev
+
+Foglamp is also open source (Apache-2.0) and free to self-host: ${GITHUB_URL}`;
+
+const ABOUT = `# About Foglamp
+
+Foglamp builds observability for AI agents: the tooling that shows what your
+LLM calls actually cost, how they behave, and when their quality drifts.
+
+## Founders
+
+- **Gustavo Fior** — co-founder & builder. Leads product and engineering, building the tools he wants when shipping AI products himself. (https://www.linkedin.com/in/gustavofior)
+- **Abdul Haidar** — co-founder, working alongside Gustavo to build clearer infrastructure for AI products. (https://www.linkedin.com/in/abdulhdr/)
+
+Founded 2026. Open source at ${GITHUB_URL}.`;
+
+const PRIVACY = `# Foglamp privacy policy
+
+The canonical, always-current privacy policy is the HTML page at
+${SITE_URL}/privacy — fetch it without an \`Accept: text/markdown\` header (or
+render it) to read the full legal text. Questions: privacy@foglamp.dev.`;
+
+const TERMS = `# Foglamp terms of service
+
+The canonical, always-current terms are the HTML page at ${SITE_URL}/terms —
+fetch it without an \`Accept: text/markdown\` header (or render it) to read the
+full legal text. Questions: legal@foglamp.dev.`;
+
+// One markdown mirror per feature page: the product tagline plus where to go
+// deeper. Taglines mirror components/marketing/products.ts.
+function feature(title: string, tagline: string, extra: string): string {
+	return `# ${title} — Foglamp
+
+> ${tagline}
+
+${extra}
+
+Part of Foglamp, observability for AI agents built on the Vercel AI SDK.
+Overview: ${SITE_URL} · Pricing: ${SITE_URL}/pricing · Docs: ${DOCS_ORIGIN}`;
+}
+
+const PAGES: Record<string, string> = {
+	"/": HOME,
+	"/homepage": HOME,
+	"/pricing": PRICING,
+	"/about": ABOUT,
+	"/privacy": PRIVACY,
+	"/terms": TERMS,
+	"/features/cost-intelligence": feature(
+		"Cost intelligence",
+		"Know exactly what every call costs, by model, agent, customer.",
+		`Every span is priced at ingest against a per-model pricing table (with
+per-project overrides), so spend rolls up by model, agent, workflow, and
+customer without any extra tagging.`,
+	),
+	"/features/evals": feature(
+		"Evals",
+		"Score production traffic with code checks and LLM judges.",
+		`Run code scorers and LLM-as-judge evals against live traces — no separate
+eval dataset required. Docs: ${DOCS_ORIGIN}/dashboard/evals`,
+	),
+	"/features/alerts": feature(
+		"Alerts",
+		"Threshold rules on cost, latency, and error rate.",
+		`Set threshold rules and get notified by email or Slack when cost, latency,
+or error rate crosses the line. Docs: ${DOCS_ORIGIN}/dashboard/alerts`,
+	),
+	"/features/agents": feature(
+		"Agents",
+		"Per-agent spans, latency, and spend - with the full call flow.",
+		`Group traces by agent to see each one's spans, latency, and spend, and
+drill into the full call flow behind any run.`,
+	),
+	"/features/distributed-traces": feature(
+		"Distributed traces",
+		"Waterfall every run, with the exact prompt and response per span.",
+		`Every generateText / streamText call becomes a span in a waterfall, with
+the exact prompt, response, token counts, and cost attached.`,
+	),
+	"/features/sdk": feature(
+		"SDK",
+		"Two lines instruments every generateText / streamText call.",
+		`Wrap your AI SDK model (v4–v7) and every call is traced automatically.
+Setup guide written for coding agents: ${DOCS_ORIGIN}/ai-instrument.md`,
+	),
+};
+
+/** Full markdown document for a marketing path, or null when none exists. */
+export function getMarkdownPage(pathname: string): string | null {
+	const normalized =
+		pathname.length > 1 && pathname.endsWith("/")
+			? pathname.slice(0, -1)
+			: pathname;
+	const body = PAGES[normalized];
+	return body ? `${body}${FOOTER}\n` : null;
+}
+
+/** All paths that have a markdown representation (for tests + sitemap checks). */
+export function markdownPagePaths(): string[] {
+	return Object.keys(PAGES);
+}
+
+/** Markdown body for a 404, pointing agents at ways to recover. */
+export function markdownNotFound(pathname: string): string {
+	return `# 404 — Not found
+
+There is no page at \`${pathname}\` on ${SITE_URL}.
+
+Where to look instead:
+
+- Site index for LLMs: ${SITE_URL}/llms.txt
+- Sitemap: ${SITE_URL}/sitemap.xml
+- Documentation: ${DOCS_ORIGIN} (index: ${DOCS_ORIGIN}/llms.txt)
+- Product overview: ${SITE_URL}
+${FOOTER}\n`;
+}

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+
+import {
+	getMarkdownPage,
+	markdownNotFound,
+	markdownPagePaths,
+} from "@/lib/markdown-pages";
+import { proxy } from "./proxy";
+
+function req(path: string, headers: Record<string, string> = {}): NextRequest {
+	return new NextRequest(`https://foglamp.dev${path}`, { headers });
+}
+
+// A NextResponse.next() pass-through carries this marker header instead of a
+// real body — that's how we tell "left for Next to render" from "responded".
+function isPassThrough(res: Response): boolean {
+	return res.headers.get("x-middleware-next") === "1";
+}
+
+describe("markdown pages", () => {
+	test("every marketing page in the map renders with a title", () => {
+		for (const path of markdownPagePaths()) {
+			const page = getMarkdownPage(path);
+			expect(page).toBeString();
+			expect(page).toStartWith("# ");
+		}
+	});
+
+	test("covers the whole indexable marketing surface (mirrors sitemap.ts)", () => {
+		const expected = [
+			"/",
+			"/pricing",
+			"/privacy",
+			"/terms",
+			"/features/cost-intelligence",
+			"/features/evals",
+			"/features/alerts",
+			"/features/agents",
+			"/features/distributed-traces",
+			"/features/sdk",
+		];
+		for (const path of expected) {
+			expect(getMarkdownPage(path)).toBeString();
+		}
+	});
+
+	test("trailing slashes normalize", () => {
+		expect(getMarkdownPage("/pricing/")).toBe(getMarkdownPage("/pricing")!);
+	});
+
+	test("404 body points at recovery routes", () => {
+		const body = markdownNotFound("/nope");
+		expect(body).toContain("/llms.txt");
+		expect(body).toContain("/sitemap.xml");
+		expect(body).toContain("docs.foglamp.dev");
+	});
+});
+
+describe("proxy content negotiation", () => {
+	test("Accept: text/markdown on a marketing page serves markdown", async () => {
+		const res = proxy(req("/pricing", { accept: "text/markdown" }));
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toBe(
+			"text/markdown; charset=utf-8",
+		);
+		expect(res.headers.get("vary")).toBe("Accept");
+		expect(await res.text()).toContain("# Foglamp pricing");
+	});
+
+	test("browser Accept passes through with Vary: Accept added", () => {
+		const res = proxy(
+			req("/", { accept: "text/html,application/xhtml+xml,*/*;q=0.8" }),
+		);
+		expect(isPassThrough(res)).toBe(true);
+		expect(res.headers.get("vary")).toContain("Accept");
+	});
+
+	test(".md alias serves markdown regardless of Accept", async () => {
+		const res = proxy(req("/pricing.md", { accept: "text/html" }));
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toBe(
+			"text/markdown; charset=utf-8",
+		);
+		expect(await res.text()).toContain("# Foglamp pricing");
+	});
+
+	test("unknown .md path is a markdown 404", async () => {
+		const res = proxy(req("/nope.md"));
+		expect(res.status).toBe(404);
+		expect(await res.text()).toContain("404");
+	});
+
+	test("markdown-preferring agent on an unknown path gets a markdown 404", async () => {
+		const res = proxy(
+			req("/some-path-that-does-not-exist", { accept: "text/markdown" }),
+		);
+		expect(res.status).toBe(404);
+		expect(res.headers.get("content-type")).toBe(
+			"text/markdown; charset=utf-8",
+		);
+		expect(await res.text()).toContain("/llms.txt");
+	});
+
+	test("dashboard routes have no markdown variant and pass through", () => {
+		const res = proxy(req("/overview", { accept: "text/markdown" }));
+		expect(isPassThrough(res)).toBe(true);
+	});
+
+	test("RSC/router requests are left completely alone", () => {
+		const res = proxy(req("/pricing", { accept: "*/*", rsc: "1" }));
+		expect(isPassThrough(res)).toBe(true);
+		expect(res.headers.get("vary")).toBeNull();
+	});
+
+	test("unsupported Accept on a negotiated page gets a 406", () => {
+		const res = proxy(req("/pricing", { accept: "application/json" }));
+		expect(res.status).toBe(406);
+		expect(res.headers.get("vary")).toBe("Accept");
+	});
+
+	test("q-values flip the winner", async () => {
+		const res = proxy(
+			req("/", { accept: "text/html;q=0.4, text/markdown" }),
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toBe(
+			"text/markdown; charset=utf-8",
+		);
+	});
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,0 +1,118 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { negotiateFormat } from "@/lib/accept";
+import {
+	getMarkdownPage,
+	markdownNotFound,
+} from "@/lib/markdown-pages";
+
+// Markdown content negotiation for the marketing surface (acceptmarkdown.com).
+// Agents that ask for `Accept: text/markdown` (or fetch `<path>.md`) get a
+// markdown representation of the page; browsers are untouched. Both variants
+// of a negotiated URL carry `Vary: Accept` so CDNs never serve the cached HTML
+// to an agent or vice versa. Unknown paths asked for as markdown get a
+// markdown 404 that points at llms.txt / sitemap / docs so agents can recover.
+
+// Routes that are real pages but have no markdown mirror: the authenticated
+// dashboard, auth flows, and interactive tools. Requests here pass through
+// untouched (mirrors the disallow list in robots.ts).
+const NON_MARKETING_PREFIXES = [
+	"/overview",
+	"/agents",
+	"/alerts",
+	"/evals",
+	"/platform",
+	"/sessions",
+	"/settings",
+	"/traces",
+	"/workflows",
+	"/login",
+	"/device",
+	"/reset-password",
+	"/accept-invitation",
+	"/scan",
+	"/setup",
+	"/hud",
+	"/buttons",
+];
+
+function isNonMarketing(pathname: string): boolean {
+	return NON_MARKETING_PREFIXES.some(
+		(p) => pathname === p || pathname.startsWith(`${p}/`),
+	);
+}
+
+function markdownResponse(body: string, status: 200 | 404 | 406): Response {
+	return new Response(body, {
+		status,
+		headers: {
+			"content-type": "text/markdown; charset=utf-8",
+			"cache-control": "public, max-age=0, must-revalidate",
+			vary: "Accept",
+		},
+	});
+}
+
+export function proxy(request: NextRequest): Response {
+	const { pathname } = request.nextUrl;
+
+	// `<path>.md` aliases always serve markdown, whatever the Accept header
+	// (mirrors how docs.foglamp.dev exposes its .md variants).
+	if (pathname.endsWith(".md")) {
+		const target = pathname.slice(0, -3) || "/";
+		const page = getMarkdownPage(target);
+		return page
+			? markdownResponse(page, 200)
+			: markdownResponse(markdownNotFound(pathname), 404);
+	}
+
+	// Next's own client-router traffic (RSC payloads, prefetches) negotiates
+	// with internal content types — never markdown. Leave it completely alone
+	// so the router cache behaves exactly as before.
+	if (
+		request.headers.get("rsc") !== null ||
+		request.headers.get("next-router-state-tree") !== null ||
+		request.headers.get("accept")?.includes("text/x-component")
+	) {
+		return NextResponse.next();
+	}
+
+	const format = negotiateFormat(request.headers.get("accept"));
+	const page = getMarkdownPage(pathname);
+
+	if (format === "markdown") {
+		if (page) return markdownResponse(page, 200);
+		// Real (non-marketing) pages just have no markdown variant — serve HTML.
+		if (isNonMarketing(pathname)) return NextResponse.next();
+		return markdownResponse(markdownNotFound(pathname), 404);
+	}
+
+	if (format === "unacceptable" && page) {
+		return markdownResponse(
+			`# 406 — Not acceptable\n\nThis URL serves \`text/html\` and \`text/markdown\`. Re-request with one of those in the Accept header.\n`,
+			406,
+		);
+	}
+
+	// HTML variant of a negotiated URL: ask for Vary: Accept so shared caches
+	// key on Accept here too. The Next server strips middleware Vary values
+	// from page responses, so the load-bearing copy of this header lives in
+	// next.config.ts `headers()` — Vercel's edge router applies that one from
+	// the routes manifest. This append is kept for self-hosted setups behind
+	// proxies that do honor middleware headers.
+	if (page) {
+		const response = NextResponse.next();
+		response.headers.append("vary", "Accept");
+		return response;
+	}
+
+	return NextResponse.next();
+}
+
+export const config = {
+	// Everything except the API, Next internals, and static assets by
+	// extension — but let `.md` through for the markdown aliases.
+	matcher: [
+		"/((?!api/|_next/|.*\\.(?:ico|png|jpe?g|svg|webp|avif|gif|css|js|map|txt|xml|json|woff2?|ttf|otf)$).*)",
+	],
+};


### PR DESCRIPTION
Implements the fixes from an **Is Agentic** audit of foglamp.dev (score 75/100), failures first.

## What changed

### 1. Agent-friendly 404s
- New `apps/web/src/app/not-found.tsx`: real 404 status with recovery links (home, pricing, docs, `llms.txt`, `sitemap.xml`) instead of the bare app shell.
- Agents requesting `Accept: text/markdown` (or any `*.md` path) get a markdown 404 body from the proxy pointing at `llms.txt` / sitemap / docs.

### 2. JSON API error responses (server + ingest)
- New `httpErrors.ts` in both Hono apps: `notFound` / `onError` fallbacks return `{ error, code, hint }` JSON instead of Hono's plain-text defaults. `HTTPException` statuses and JSON bodies pass through untouched.

### 3. Markdown content negotiation (acceptmarkdown.com)
- `apps/web/src/proxy.ts` (Next 16 proxy) + `lib/accept.ts` (RFC 9110 q-value negotiation) + `lib/markdown-pages.ts` (markdown mirrors of all 12 marketing pages).
- `Accept: text/markdown` → `200 text/markdown; charset=utf-8` + `Vary: Accept`; q-values honored; unsupported-only Accept → `406`; `.md` aliases (e.g. `/pricing.md`). RSC/router-prefetch traffic is explicitly bypassed, so client nav is untouched.
- The HTML variant's `Vary: Accept` is set via `next.config.ts` `headers()` — the Next server strips custom Vary from page responses, but Vercel's edge applies the routes-manifest headers. **Verify after deploy:** `curl -sI https://www.foglamp.dev/pricing | grep -i vary`.

### 4. Heading structure without JS
- `sr-only` h2 (wired via `aria-labelledby`) gives the DriftStory section a place in the document outline. No visual change.

### 5. Developer discoverability
- `llms.txt`: "Foglamp developer resources" section (API reference, OpenAPI spec, changelog, repo) + notes for agents about the markdown negotiation.
- `/openapi.json` 307-redirects to the canonical spec on docs.foglamp.dev.

## Tests / verification
- New suites: `accept.test.ts` (12), `proxy.test.ts` (13), `httpErrors.test.ts` ×2 (4 each) — all green; web/server/ingest suites pass; `tsc --noEmit` clean; `next build` clean.
- Verified end-to-end against a local `next build && next start`: 404 status+body, markdown 404, negotiation + q-value flip, `.md` alias, 406, openapi redirect, RSC passthrough.

## Note for reviewers
- `lib/markdown-pages.ts` mirrors pricing limits and taglines by hand — keep in sync when those pages change (comments at both ends call it out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VygBx7vo8H9GcCKffmrkBA