### PR TITLE
feat(setup): editable decisions on the review page (Stage 2)

### DIFF
--- a/apps/web/src/app/setup/[planId]/setup-client.tsx
+++ b/apps/web/src/app/setup/[planId]/setup-client.tsx
@@ -136,7 +136,7 @@ export function SetupClient({ planId }: { planId: string }) {
         status={data.status}
         firstTraceId={data.firstTraceId}
         failureStage={data.failureStage}
-        onApprove={() => approve.mutate({ planId })}
+        onApprove={(edits) => approve.mutate({ planId, edits })}
         onReject={() => reject.mutate({ planId })}
         approving={approve.isPending || reject.isPending}
       />

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -306,10 +306,10 @@ function Section({
 
   return (
     <section className="mt-5 px-1 first:mt-1">
-      <h2 className="mb-3 ml-px flex items-center gap-2 text-[13px] text-muted-foreground">
+      <h2 className="mb-3 ml-px flex items-center gap-2 text-[13px] text-muted-foreground w-full">
         <Icon className={cn("size-3.5 mb-px", iconClassName)} />
-        <span className="leading-none font-medium text-foreground">
-          {label} <span className="opacity-50">{entries.length}</span>
+        <span className="leading-none font-medium text-foreground w-full">
+          {label} <span className="opacity-50 ml-auto">{entries.length}</span>
         </span>
       </h2>
       <ul className="flex list-none flex-col gap-0.5">

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -5,22 +5,28 @@ import type {
   DetectedPlan,
 } from "@foglamp/contracts/instrumentation";
 import { Card, CardContent } from "@foglamp/ui/components/card";
+import { Checkbox } from "@foglamp/ui/components/checkbox";
+import { Input } from "@foglamp/ui/components/input";
 import { cn } from "@foglamp/ui/lib/utils";
 import {
   IconGhostFilled,
   IconMessage2Filled,
+  IconPencil,
   type IconProps,
   IconSitemapFilled,
   IconUserFilled,
 } from "@tabler/icons-react";
 import { type ComponentType, memo, useState } from "react";
 
-import type { SetupFocus } from "./setup-board";
+import type { EditsState, SetupFocus } from "./setup-board";
 
 // What Foglamp decided, and why — one card, styled like the scan's left rail:
 // airy sections instead of bordered rows, all scrolling inside the card so the
-// page never scrolls. Each section opens with its first few entries and a
-// "Show N more" toggle. Read-only for now; editing is the next stage.
+// page never scrolls. While the plan is awaiting approval every row is
+// editable in place: names, one-off flags, and the run/session/customer id
+// sources. Edits are overrides on top of the DETECTED values — the map keeps
+// targeting the detected names, and clearing a field falls back to what the
+// agent found.
 
 /** Entries shown per section before folding behind "Show N more". */
 const SHOWN = 4;
@@ -46,6 +52,31 @@ function ConfidenceDot({ level }: { level: Confidence }) {
   );
 }
 
+/** One override commit from a row editor. `undefined` clears the override. */
+export type EditPatch =
+  | { kind: "agent"; id: string; name?: string; oneOff?: boolean }
+  | { kind: "workflow"; id: string; name?: string; runIdSource?: string }
+  | { kind: "session"; id: string; label?: string; sessionIdSource?: string }
+  | { kind: "customer"; recommended?: boolean; idSource?: string };
+
+/** A text field inside a row editor: label, current value, commit target. */
+interface EditField {
+  key: string;
+  label: string;
+  value: string;
+  detected: string;
+  maxLength: number;
+  commit: (value: string | undefined) => void;
+}
+
+/** An on/off flag inside a row editor. */
+interface EditFlag {
+  label: string;
+  value: boolean;
+  detected: boolean;
+  commit: (value: boolean | undefined) => void;
+}
+
 interface Entry {
   key: string;
   name: string;
@@ -55,26 +86,114 @@ interface Entry {
   confidence: Confidence;
   /** What this row spotlights on the map while hovered, if anything. */
   focus?: NonNullable<SetupFocus>;
+  /** Any override currently diverging from the detected value. */
+  edited?: boolean;
+  fields?: EditField[];
+  flag?: EditFlag;
+}
+
+// Committing on blur/Enter (not per keystroke) keeps the full-viewport map
+// from re-rendering while the user types.
+function FieldInput({ field }: { field: EditField }) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[10px] text-muted-foreground">{field.label}</span>
+      <Input
+        defaultValue={field.value}
+        maxLength={field.maxLength}
+        placeholder={field.detected}
+        className="h-7 rounded-lg px-2 text-[12px] md:text-[12px]"
+        onBlur={(e) => {
+          const v = e.currentTarget.value.trim();
+          field.commit(v === "" || v === field.detected ? undefined : v);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
+      />
+    </label>
+  );
+}
+
+function RowEditor({
+  entry,
+  onDone,
+  onReset,
+}: {
+  entry: Entry;
+  onDone: () => void;
+  onReset: () => void;
+}) {
+  return (
+    <div
+      className="mt-1.5 flex flex-col gap-2 rounded-lg bg-muted/60 p-2.5"
+      // Clicks inside the editor must not fly the map or toggle the row.
+      onClick={(e) => e.stopPropagation()}
+    >
+      {entry.fields?.map((f) => <FieldInput key={f.key} field={f} />)}
+      {entry.flag ? (
+        <label className="flex cursor-pointer items-center gap-2 py-0.5 text-[11px]">
+          <Checkbox
+            checked={entry.flag.value}
+            onCheckedChange={(checked) =>
+              entry.flag!.commit(
+                checked === entry.flag!.detected ? undefined : checked
+              )
+            }
+          />
+          {entry.flag.label}
+        </label>
+      ) : null}
+      <div className="flex items-center justify-end gap-3">
+        {entry.edited ? (
+          <button
+            type="button"
+            onClick={onReset}
+            className="text-[10px] cursor-pointer text-muted-foreground/70 hover:text-foreground"
+          >
+            Reset
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={onDone}
+          className="text-[10px] font-medium cursor-pointer text-foreground/80 hover:text-foreground"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
 }
 
 function Row({
   entry,
+  editable,
   onFocus,
   onSelect,
+  onReset,
 }: {
   entry: Entry;
+  editable: boolean;
   onFocus?: (focus: SetupFocus) => void;
   onSelect?: (focus: NonNullable<SetupFocus>) => void;
+  onReset?: (entry: Entry) => void;
 }) {
+  // The editor is uncontrolled and keyed by nothing, so closing it drops any
+  // half-typed value that was never committed — exactly right for "Done".
+  const [editing, setEditing] = useState(false);
   const hoverable = entry.focus !== undefined && onFocus !== undefined;
-  const clickable = entry.focus !== undefined && onSelect !== undefined;
+  const clickable =
+    entry.focus !== undefined && onSelect !== undefined && !editing;
+  const canEdit =
+    editable && (entry.fields !== undefined || entry.flag !== undefined);
   return (
     <li
       className={cn(
-        "flex flex-col gap-0.5",
+        "group/row flex flex-col gap-0.5",
         // The row is the legend now: hovering it spotlights its subject on
         // the map, so give it a whisper of hover feedback of its own.
-        hoverable &&
+        (hoverable || canEdit) &&
           "-mx-3 rounded-md px-3 py-1.5 hover:bg-muted/60 select-none",
         clickable && "cursor-pointer"
       )}
@@ -84,22 +203,63 @@ function Row({
       onClick={clickable ? () => onSelect(entry.focus!) : undefined}
     >
       <div className="flex items-baseline justify-between gap-3">
-        <span className="truncate text-[13px]">{entry.name}</span>
-        <ConfidenceDot level={entry.confidence} />
+        <span className="flex min-w-0 items-baseline gap-1.5">
+          <span className="truncate text-[13px]">{entry.name}</span>
+          {entry.edited ? (
+            <span
+              className="shrink-0 text-[9px] font-medium text-sky-600 dark:text-sky-400"
+              title="Changed from what was detected"
+            >
+              edited
+            </span>
+          ) : null}
+        </span>
+        <span className="flex shrink-0 items-center gap-2">
+          <ConfidenceDot level={entry.confidence} />
+          {canEdit ? (
+            <button
+              type="button"
+              aria-label={`Edit ${entry.name}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                setEditing((v) => !v);
+              }}
+              className={cn(
+                "cursor-pointer text-muted-foreground/40 hover:text-foreground",
+                // Reveal on row hover; stay visible while the editor is open.
+                !editing &&
+                  "opacity-0 transition-opacity group-hover/row:opacity-100",
+                editing && "text-foreground"
+              )}
+            >
+              <IconPencil className="size-3.5" />
+            </button>
+          ) : null}
+        </span>
       </div>
-      {entry.detail ? (
-        <p className="text-[11px] line-clamp-2 text-muted-foreground">
-          {entry.detail}
-        </p>
-      ) : null}
-      <p className="line-clamp-1 text-[11px] leading-relaxed text-muted-foreground mt-0.75">
-        {entry.rationale}
-      </p>
-      {entry.sourceRef ? (
-        <p className="truncate font-mono text-[9px] text-muted-foreground/50 mt-0.5">
-          {entry.sourceRef}
-        </p>
-      ) : null}
+      {editing ? (
+        <RowEditor
+          entry={entry}
+          onDone={() => setEditing(false)}
+          onReset={() => onReset?.(entry)}
+        />
+      ) : (
+        <>
+          {entry.detail ? (
+            <p className="text-[11px] line-clamp-2 text-muted-foreground">
+              {entry.detail}
+            </p>
+          ) : null}
+          <p className="line-clamp-1 text-[11px] leading-relaxed text-muted-foreground mt-0.75">
+            {entry.rationale}
+          </p>
+          {entry.sourceRef ? (
+            <p className="truncate font-mono text-[9px] text-muted-foreground/50 mt-0.5">
+              {entry.sourceRef}
+            </p>
+          ) : null}
+        </>
+      )}
     </li>
   );
 }
@@ -109,16 +269,20 @@ function Section({
   Icon,
   iconClassName,
   entries,
+  editable,
   onFocus,
   onSelect,
+  onReset,
 }: {
   label: string;
   Icon: ComponentType<IconProps>;
   /** Map vocabulary: the same tint this thing carries on the flow map. */
   iconClassName: string;
   entries: Entry[];
+  editable: boolean;
   onFocus?: (focus: SetupFocus) => void;
   onSelect?: (focus: NonNullable<SetupFocus>) => void;
+  onReset?: (entry: Entry) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   if (entries.length === 0) return null;
@@ -135,7 +299,14 @@ function Section({
       </h2>
       <ul className="flex list-none flex-col gap-0.5">
         {shown.map((e) => (
-          <Row key={e.key} entry={e} onFocus={onFocus} onSelect={onSelect} />
+          <Row
+            key={e.key}
+            entry={e}
+            editable={editable}
+            onFocus={onFocus}
+            onSelect={onSelect}
+            onReset={onReset}
+          />
         ))}
       </ul>
       {hidden > 0 ? (
@@ -151,20 +322,38 @@ function Section({
   );
 }
 
+/** Override wins unless it was cleared. */
+function eff<T>(override: T | undefined, detected: T): T {
+  return override ?? detected;
+}
+
+function isEdited<T>(override: T | undefined, detected: T): boolean {
+  return override !== undefined && override !== detected;
+}
+
 // Memoized: hover-driven focus renders in the parent shouldn't re-render the
-// list that's being hovered (its props are stable — the plan object and a
-// useCallback'd onFocus).
+// list that's being hovered. Edit commits DO re-render it (the `edits` prop
+// changes), which is the point.
 export const DecisionList = memo(function DecisionList({
   plan,
+  edits,
+  editable,
+  onEdit,
   onFocus,
   onSelect,
 }: {
   plan: DetectedPlan;
+  edits: EditsState;
+  /** Rows accept changes only while the plan is awaiting approval. */
+  editable: boolean;
+  onEdit: (patch: EditPatch) => void;
   onFocus?: (focus: SetupFocus) => void;
   /** Click-to-focus: fly the map to the row's subject. */
   onSelect?: (focus: NonNullable<SetupFocus>) => void;
 }) {
   const { agents, workflows, sessions, customer } = plan.decisions;
+  const customerOn = eff(edits.customer?.recommended, customer.recommended);
+  const customerIdSource = eff(edits.customer?.idSource, customer.idSource);
 
   return (
     <Card className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[36px] squircle:rounded-[36px] py-0">
@@ -175,64 +364,205 @@ export const DecisionList = memo(function DecisionList({
           label="Agents"
           Icon={IconGhostFilled}
           iconClassName="text-orange-500"
+          editable={editable}
           onFocus={onFocus}
           onSelect={onSelect}
-          entries={agents.map((a) => ({
-            key: a.id,
-            name: a.name,
-            focus: { type: "agent" as const, name: a.name },
-            detail: a.oneOff ? "One-off trace" : undefined,
-            sourceRef: a.sourceRef,
-            rationale: a.rationale,
-            confidence: a.confidence,
-          }))}
+          onReset={(e) => onEdit({ kind: "agent", id: e.key })}
+          entries={agents.map((a) => {
+            const o = edits.agents[a.id];
+            const oneOff = eff(o?.oneOff, a.oneOff ?? false);
+            return {
+              key: a.id,
+              name: eff(o?.name, a.name),
+              // The map draws the DETECTED graph — renaming the decision must
+              // not break the row's spotlight, so focus keeps the found name.
+              focus: { type: "agent" as const, name: a.name },
+              detail: oneOff ? "One-off trace" : undefined,
+              sourceRef: a.sourceRef,
+              rationale: a.rationale,
+              confidence: a.confidence,
+              edited:
+                isEdited(o?.name, a.name) ||
+                isEdited(o?.oneOff, a.oneOff ?? false),
+              fields: [
+                {
+                  key: "name",
+                  label: "Agent name",
+                  value: eff(o?.name, a.name),
+                  detected: a.name,
+                  maxLength: 48,
+                  commit: (name: string | undefined) =>
+                    onEdit({ kind: "agent", id: a.id, name, oneOff: o?.oneOff }),
+                },
+              ],
+              flag: {
+                label: "One-off trace (no agent loop)",
+                value: oneOff,
+                detected: a.oneOff ?? false,
+                commit: (flag: boolean | undefined) =>
+                  onEdit({ kind: "agent", id: a.id, name: o?.name, oneOff: flag }),
+              },
+            };
+          })}
         />
         <Section
           label="Workflows"
           Icon={IconSitemapFilled}
           iconClassName="text-emerald-500"
+          editable={editable}
           onFocus={onFocus}
           onSelect={onSelect}
-          entries={workflows.map((w) => ({
-            key: w.id,
-            name: w.name,
-            focus: { type: "workflow" as const, name: w.name },
-            detail: `Run id from ${w.runIdSource}`,
-            sourceRef: w.sourceRef,
-            rationale: w.rationale,
-            confidence: w.confidence,
-          }))}
+          onReset={(e) => onEdit({ kind: "workflow", id: e.key })}
+          entries={workflows.map((w) => {
+            const o = edits.workflows[w.id];
+            const runIdSource = eff(o?.runIdSource, w.runIdSource);
+            return {
+              key: w.id,
+              name: eff(o?.name, w.name),
+              focus: { type: "workflow" as const, name: w.name },
+              detail: `Run id from ${runIdSource}`,
+              sourceRef: w.sourceRef,
+              rationale: w.rationale,
+              confidence: w.confidence,
+              edited:
+                isEdited(o?.name, w.name) ||
+                isEdited(o?.runIdSource, w.runIdSource),
+              fields: [
+                {
+                  key: "name",
+                  label: "Workflow name",
+                  value: eff(o?.name, w.name),
+                  detected: w.name,
+                  maxLength: 48,
+                  commit: (name: string | undefined) =>
+                    onEdit({
+                      kind: "workflow",
+                      id: w.id,
+                      name,
+                      runIdSource: o?.runIdSource,
+                    }),
+                },
+                {
+                  key: "runIdSource",
+                  label: "Run id comes from",
+                  value: runIdSource,
+                  detected: w.runIdSource,
+                  maxLength: 160,
+                  commit: (src: string | undefined) =>
+                    onEdit({
+                      kind: "workflow",
+                      id: w.id,
+                      name: o?.name,
+                      runIdSource: src,
+                    }),
+                },
+              ],
+            };
+          })}
         />
 
         <Section
           label="Conversations"
           Icon={IconMessage2Filled}
           iconClassName="text-sky-500"
-          entries={sessions.map((s) => ({
-            key: s.id,
-            name: s.label,
-            detail: `Thread id from ${s.sessionIdSource}`,
-            sourceRef: s.sourceRef,
-            rationale: s.rationale,
-            confidence: s.confidence,
-          }))}
+          editable={editable}
+          onReset={(e) => onEdit({ kind: "session", id: e.key })}
+          entries={sessions.map((s) => {
+            const o = edits.sessions[s.id];
+            const sessionIdSource = eff(o?.sessionIdSource, s.sessionIdSource);
+            return {
+              key: s.id,
+              name: eff(o?.label, s.label),
+              detail: `Thread id from ${sessionIdSource}`,
+              sourceRef: s.sourceRef,
+              rationale: s.rationale,
+              confidence: s.confidence,
+              edited:
+                isEdited(o?.label, s.label) ||
+                isEdited(o?.sessionIdSource, s.sessionIdSource),
+              fields: [
+                {
+                  key: "label",
+                  label: "Conversation label",
+                  value: eff(o?.label, s.label),
+                  detected: s.label,
+                  maxLength: 48,
+                  commit: (label: string | undefined) =>
+                    onEdit({
+                      kind: "session",
+                      id: s.id,
+                      label,
+                      sessionIdSource: o?.sessionIdSource,
+                    }),
+                },
+                {
+                  key: "sessionIdSource",
+                  label: "Thread id comes from",
+                  value: sessionIdSource,
+                  detected: s.sessionIdSource,
+                  maxLength: 160,
+                  commit: (src: string | undefined) =>
+                    onEdit({
+                      kind: "session",
+                      id: s.id,
+                      label: o?.label,
+                      sessionIdSource: src,
+                    }),
+                },
+              ],
+            };
+          })}
         />
         {/* Always shown, including the "no" answer — a user should be able to
-            see that per-customer attribution was considered and skipped. */}
+            see that per-customer attribution was considered and skipped, and
+            flip it on if they know better. */}
         <Section
           label="Customer attribution"
           Icon={IconUserFilled}
           iconClassName="text-violet-500"
+          editable={editable}
+          onReset={() => onEdit({ kind: "customer" })}
           entries={[
             {
               key: "customer",
-              name: customer.recommended ? "Enabled" : "Not recommended",
+              name: customerOn ? "Enabled" : "Not recommended",
               detail:
-                customer.recommended && customer.idSource
-                  ? `Customer id from ${customer.idSource}`
-                  : undefined,
+                customerOn && customerIdSource
+                  ? `Customer id from ${customerIdSource}`
+                  : customerOn
+                    ? "Needs a customer id source before approving"
+                    : undefined,
               rationale: customer.rationale,
               confidence: customer.confidence,
+              edited:
+                isEdited(edits.customer?.recommended, customer.recommended) ||
+                isEdited(edits.customer?.idSource, customer.idSource),
+              fields: [
+                {
+                  key: "idSource",
+                  label: "Customer id comes from",
+                  value: customerIdSource ?? "",
+                  detected: customer.idSource ?? "",
+                  maxLength: 160,
+                  commit: (src: string | undefined) =>
+                    onEdit({
+                      kind: "customer",
+                      recommended: edits.customer?.recommended,
+                      idSource: src,
+                    }),
+                },
+              ],
+              flag: {
+                label: "Attribute traces to customers",
+                value: customerOn,
+                detected: customer.recommended,
+                commit: (on: boolean | undefined) =>
+                  onEdit({
+                    kind: "customer",
+                    recommended: on,
+                    idSource: edits.customer?.idSource,
+                  }),
+              },
             },
           ]}
         />

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -82,8 +82,8 @@ interface Entry {
   key: string;
   name: string;
   detail?: string;
-  /** Tint for the detail line, when it should echo the section's color. */
-  detailClassName?: string;
+  /** Small tinted label sitting beside the name (e.g. "Agent loop"). */
+  tag?: { text: string; className?: string };
   sourceRef?: string;
   rationale: string;
   confidence: Confidence;
@@ -210,6 +210,16 @@ function Row({
       <div className="flex items-center justify-between gap-3">
         <span className="flex min-w-0 items-baseline gap-1.5">
           <span className="truncate text-[13px]">{entry.name}</span>
+          {entry.tag ? (
+            <span
+              className={cn(
+                "shrink-0 text-[10px] font-medium",
+                entry.tag.className
+              )}
+            >
+              {entry.tag.text}
+            </span>
+          ) : null}
           {entry.edited ? (
             <span
               className="shrink-0 text-[9px] font-medium text-sky-600 dark:text-sky-400"
@@ -251,12 +261,7 @@ function Row({
       ) : (
         <>
           {entry.detail ? (
-            <p
-              className={cn(
-                "text-[11px] line-clamp-2 text-muted-foreground",
-                entry.detailClassName
-              )}
-            >
+            <p className="text-[11px] line-clamp-2 text-muted-foreground">
               {entry.detail}
             </p>
           ) : null}
@@ -389,10 +394,11 @@ export const DecisionList = memo(function DecisionList({
               focus: { type: "agent" as const, name: a.name },
               // One-off is the unremarkable case — only a real agent loop
               // earns a label.
-              detail: oneOff ? undefined : "Agent loop",
               // Same orange as the section's ghost icon — the label IS the
               // map vocabulary.
-              detailClassName: "text-orange-500 mt-0.5",
+              tag: oneOff
+                ? undefined
+                : { text: "Agent loop", className: "text-orange-500" },
               sourceRef: a.sourceRef,
               rationale: a.rationale,
               confidence: a.confidence,

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -12,6 +12,7 @@ import {
   IconGhostFilled,
   IconMessage2Filled,
   IconPencil,
+  IconPencilFilled,
   type IconProps,
   IconSitemapFilled,
   IconUserFilled,
@@ -130,7 +131,9 @@ function RowEditor({
       // Clicks inside the editor must not fly the map or toggle the row.
       onClick={(e) => e.stopPropagation()}
     >
-      {entry.fields?.map((f) => <FieldInput key={f.key} field={f} />)}
+      {entry.fields?.map((f) => (
+        <FieldInput key={f.key} field={f} />
+      ))}
       {entry.flag ? (
         <label className="flex cursor-pointer items-center gap-2 py-0.5 text-[11px]">
           <Checkbox
@@ -202,7 +205,7 @@ function Row({
       // Clicking flies the map to the row's subject (the hover only dims).
       onClick={clickable ? () => onSelect(entry.focus!) : undefined}
     >
-      <div className="flex items-baseline justify-between gap-3">
+      <div className="flex items-center justify-between gap-3">
         <span className="flex min-w-0 items-baseline gap-1.5">
           <span className="truncate text-[13px]">{entry.name}</span>
           {entry.edited ? (
@@ -225,14 +228,14 @@ function Row({
                 setEditing((v) => !v);
               }}
               className={cn(
-                "cursor-pointer text-muted-foreground/40 hover:text-foreground",
+                "cursor-pointer text-muted-foreground hover:text-foreground",
                 // Reveal on row hover; stay visible while the editor is open.
                 !editing &&
                   "opacity-0 transition-opacity group-hover/row:opacity-100",
                 editing && "text-foreground"
               )}
             >
-              <IconPencil className="size-3.5" />
+              <IconPencilFilled className="size-3.5" />
             </button>
           ) : null}
         </span>
@@ -377,7 +380,9 @@ export const DecisionList = memo(function DecisionList({
               // The map draws the DETECTED graph — renaming the decision must
               // not break the row's spotlight, so focus keeps the found name.
               focus: { type: "agent" as const, name: a.name },
-              detail: oneOff ? "One-off trace" : undefined,
+              // One-off is the unremarkable case — only a real agent loop
+              // earns a label.
+              detail: oneOff ? undefined : "Agent loop",
               sourceRef: a.sourceRef,
               rationale: a.rationale,
               confidence: a.confidence,
@@ -392,7 +397,12 @@ export const DecisionList = memo(function DecisionList({
                   detected: a.name,
                   maxLength: 48,
                   commit: (name: string | undefined) =>
-                    onEdit({ kind: "agent", id: a.id, name, oneOff: o?.oneOff }),
+                    onEdit({
+                      kind: "agent",
+                      id: a.id,
+                      name,
+                      oneOff: o?.oneOff,
+                    }),
                 },
               ],
               flag: {
@@ -400,7 +410,12 @@ export const DecisionList = memo(function DecisionList({
                 value: oneOff,
                 detected: a.oneOff ?? false,
                 commit: (flag: boolean | undefined) =>
-                  onEdit({ kind: "agent", id: a.id, name: o?.name, oneOff: flag }),
+                  onEdit({
+                    kind: "agent",
+                    id: a.id,
+                    name: o?.name,
+                    oneOff: flag,
+                  }),
               },
             };
           })}

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -82,6 +82,8 @@ interface Entry {
   key: string;
   name: string;
   detail?: string;
+  /** Tint for the detail line, when it should echo the section's color. */
+  detailClassName?: string;
   sourceRef?: string;
   rationale: string;
   confidence: Confidence;
@@ -249,7 +251,12 @@ function Row({
       ) : (
         <>
           {entry.detail ? (
-            <p className="text-[11px] line-clamp-2 text-muted-foreground">
+            <p
+              className={cn(
+                "text-[11px] line-clamp-2 text-muted-foreground",
+                entry.detailClassName
+              )}
+            >
               {entry.detail}
             </p>
           ) : null}
@@ -383,6 +390,9 @@ export const DecisionList = memo(function DecisionList({
               // One-off is the unremarkable case — only a real agent loop
               // earns a label.
               detail: oneOff ? undefined : "Agent loop",
+              // Same orange as the section's ghost icon — the label IS the
+              // map vocabulary.
+              detailClassName: "text-orange-500",
               sourceRef: a.sourceRef,
               rationale: a.rationale,
               confidence: a.confidence,

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -129,7 +129,7 @@ function RowEditor({
 }) {
   return (
     <div
-      className="mt-1.5 flex flex-col gap-2 rounded-lg bg-muted/60 p-2.5"
+      className="mt-1.5 flex flex-col gap-2"
       // Clicks inside the editor must not fly the map or toggle the row.
       onClick={(e) => e.stopPropagation()}
     >
@@ -213,7 +213,7 @@ function Row({
           {entry.tag ? (
             <span
               className={cn(
-                "shrink-0 text-[10px] font-medium",
+                "shrink-0 text-[11px] font-medium",
                 entry.tag.className
               )}
             >
@@ -222,10 +222,10 @@ function Row({
           ) : null}
           {entry.edited ? (
             <span
-              className="shrink-0 text-[9px] font-medium text-sky-600 dark:text-sky-400"
+              className="shrink-0 text-[11px] font-medium text-sky-600 dark:text-sky-400"
               title="Changed from what was detected"
             >
-              edited
+              Edited
             </span>
           ) : null}
         </span>
@@ -306,10 +306,11 @@ function Section({
 
   return (
     <section className="mt-5 px-1 first:mt-1">
-      <h2 className="mb-3 ml-px flex items-center gap-2 text-[13px] text-muted-foreground w-full">
+      <h2 className="mb-3 ml-px flex items-center gap-2 text-[13px] text-muted-foreground">
         <Icon className={cn("size-3.5 mb-px", iconClassName)} />
-        <span className="leading-none font-medium text-foreground w-full">
-          {label} <span className="opacity-50 ml-auto">{entries.length}</span>
+        <span className="leading-none font-medium text-foreground">
+          {label}{" "}
+          <span className="opacity-50 ml-1 tabular-nums">{entries.length}</span>
         </span>
       </h2>
       <ul className="flex list-none flex-col gap-0.5">

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -5,8 +5,8 @@ import type {
   DetectedPlan,
 } from "@foglamp/contracts/instrumentation";
 import { Card, CardContent } from "@foglamp/ui/components/card";
-import { Checkbox } from "@foglamp/ui/components/checkbox";
 import { Input } from "@foglamp/ui/components/input";
+import { Switch } from "@foglamp/ui/components/switch";
 import { cn } from "@foglamp/ui/lib/utils";
 import {
   IconGhostFilled,
@@ -133,12 +133,11 @@ function RowEditor({
       // Clicks inside the editor must not fly the map or toggle the row.
       onClick={(e) => e.stopPropagation()}
     >
-      {entry.fields?.map((f) => (
-        <FieldInput key={f.key} field={f} />
-      ))}
       {entry.flag ? (
-        <label className="flex cursor-pointer items-center gap-2 py-0.5 text-[11px]">
-          <Checkbox
+        <label className="flex cursor-pointer items-center justify-between gap-2 py-0.5 text-[11px]">
+          {entry.flag.label}
+          <Switch
+            size="sm"
             checked={entry.flag.value}
             onCheckedChange={(checked) =>
               entry.flag!.commit(
@@ -146,9 +145,11 @@ function RowEditor({
               )
             }
           />
-          {entry.flag.label}
         </label>
       ) : null}
+      {entry.fields?.map((f) => (
+        <FieldInput key={f.key} field={f} />
+      ))}
       <div className="flex items-center justify-end gap-3">
         {entry.edited ? (
           <button

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -148,7 +148,9 @@ function RowEditor({
         </label>
       ) : null}
       {entry.fields?.map((f) => (
-        <FieldInput key={f.key} field={f} />
+        // Keyed by the committed value: the inputs are uncontrolled, so a
+        // Reset (or any outside change) must remount them to show it.
+        <FieldInput key={`${f.key}:${f.value}`} field={f} />
       ))}
       <div className="flex items-center justify-end gap-3">
         {entry.edited ? (
@@ -253,7 +255,9 @@ function Row({
           ) : null}
         </span>
       </div>
-      {editing ? (
+      {/* `canEdit` too: if the plan stops being editable while a form is
+          open (approved from another tab, expired), the form must go. */}
+      {editing && canEdit ? (
         <RowEditor
           entry={entry}
           onDone={() => setEditing(false)}

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -392,7 +392,7 @@ export const DecisionList = memo(function DecisionList({
               detail: oneOff ? undefined : "Agent loop",
               // Same orange as the section's ghost icon — the label IS the
               // map vocabulary.
-              detailClassName: "text-orange-500",
+              detailClassName: "text-orange-500 mt-0.5",
               sourceRef: a.sourceRef,
               rationale: a.rationale,
               confidence: a.confidence,

--- a/apps/web/src/components/setup/setup-board.tsx
+++ b/apps/web/src/components/setup/setup-board.tsx
@@ -5,7 +5,14 @@ import type {
   PlanEdits,
   PlanStatus,
 } from "@foglamp/contracts/instrumentation";
-import { startTransition, useCallback, useMemo, useState } from "react";
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { FlowMap, type MapZoomTarget } from "@/components/scan/flow-map";
 
@@ -67,13 +74,26 @@ export function SetupBoard({
   approving: boolean;
 }) {
   const [focus, setFocusState] = useState<SetupFocus>(null);
-  // Spotlighting re-renders the whole map, and as a blocking update every
-  // mouseenter janked the cursor. As a transition the row's own hover feedback
-  // stays instant, and React can abandon a stale spotlight render when the
-  // pointer sweeps across several rows.
+  // Spotlighting re-renders the whole map, so hover commits are debounced:
+  // scrolling (or sweeping the pointer down) the list fires mouseenter on
+  // every row it passes, and rendering the map once per row is what made the
+  // list feel laggy. Only the row the cursor actually RESTS on gets a render
+  // — consecutive calls coalesce to the last one. The commit itself is still
+  // a transition, so React can abandon it if a newer focus lands mid-render.
+  const focusTimer = useRef<number | null>(null);
   const setFocus = useCallback((focus: SetupFocus) => {
-    startTransition(() => setFocusState(focus));
+    if (focusTimer.current !== null) window.clearTimeout(focusTimer.current);
+    focusTimer.current = window.setTimeout(() => {
+      focusTimer.current = null;
+      startTransition(() => setFocusState(focus));
+    }, 90);
   }, []);
+  useEffect(
+    () => () => {
+      if (focusTimer.current !== null) window.clearTimeout(focusTimer.current);
+    },
+    []
+  );
   // Clicking a row flies the map to its subject. A fresh object per click on
   // purpose: re-clicking the same row after panning away re-centers it.
   const [zoom, setZoom] = useState<MapZoomTarget | null>(null);

--- a/apps/web/src/components/setup/setup-board.tsx
+++ b/apps/web/src/components/setup/setup-board.tsx
@@ -2,13 +2,14 @@
 
 import type {
   DetectedPlan,
+  PlanEdits,
   PlanStatus,
 } from "@foglamp/contracts/instrumentation";
 import { startTransition, useCallback, useMemo, useState } from "react";
 
 import { FlowMap, type MapZoomTarget } from "@/components/scan/flow-map";
 
-import { DecisionList } from "./decision-list";
+import { DecisionList, type EditPatch } from "./decision-list";
 import { SetupSummary } from "./setup-summary";
 
 // Hovering a decision row spotlights its subject on the map: a single agent
@@ -17,6 +18,27 @@ export type SetupFocus =
   | { type: "agent"; name: string }
   | { type: "workflow"; name: string }
   | null;
+
+/**
+ * Review-time overrides, keyed by decision id. Only divergence from the
+ * detected values is stored; approving converts whatever remains into the
+ * `PlanEdits` patch the server merges (server-side, onto ITS copy — the
+ * browser never ships a whole decisions blob).
+ */
+export interface EditsState {
+  agents: Record<string, { name?: string; oneOff?: boolean }>;
+  workflows: Record<string, { name?: string; runIdSource?: string }>;
+  sessions: Record<string, { label?: string; sessionIdSource?: string }>;
+  customer?: { recommended?: boolean; idSource?: string };
+}
+
+const NO_EDITS: EditsState = { agents: {}, workflows: {}, sessions: {} };
+
+/** Drop `undefined` fields; return undefined when nothing survives. */
+function compact<T extends Record<string, unknown>>(o: T): T | undefined {
+  const entries = Object.entries(o).filter(([, v]) => v !== undefined);
+  return entries.length ? (Object.fromEntries(entries) as T) : undefined;
+}
 
 // The review surface. Shares the map with the public scan board, but nothing
 // else: no attribution, no rail, no share affordances — the user is already
@@ -40,7 +62,7 @@ export function SetupBoard({
   status: PlanStatus;
   firstTraceId?: string | null;
   failureStage?: string | null;
-  onApprove: () => void;
+  onApprove: (edits: PlanEdits | undefined) => void;
   onReject: () => void;
   approving: boolean;
 }) {
@@ -62,8 +84,62 @@ export function SetupBoard({
         : { groups: [focus.name] }
     );
   }, []);
+
+  // Each patch carries the row's WHOLE override (the editor threads untouched
+  // fields through), so merging is replacement: compact the patch, then store
+  // or delete the row.
+  const [edits, setEdits] = useState<EditsState>(NO_EDITS);
+  const applyEdit = useCallback((patch: EditPatch) => {
+    setEdits((prev) => {
+      if (patch.kind === "customer") {
+        const row = compact({
+          recommended: patch.recommended,
+          idSource: patch.idSource,
+        });
+        return { ...prev, customer: row };
+      }
+      const { kind, id, ...fields } = patch;
+      const key = (
+        { agent: "agents", workflow: "workflows", session: "sessions" } as const
+      )[kind];
+      const rows = { ...prev[key] } as Record<string, object>;
+      const row = compact(fields);
+      if (row) rows[id] = row;
+      else delete rows[id];
+      return { ...prev, [key]: rows };
+    });
+  }, []);
+
+  // The wire shape: arrays of {id, ...changes}. Overrides equal to the
+  // detected value were never stored, so everything here is a real change.
+  const buildEdits = useCallback((): PlanEdits | undefined => {
+    const agents = Object.entries(edits.agents).map(([id, e]) => ({
+      id,
+      ...e,
+    }));
+    const workflows = Object.entries(edits.workflows).map(([id, e]) => ({
+      id,
+      ...e,
+    }));
+    const sessions = Object.entries(edits.sessions).map(([id, e]) => ({
+      id,
+      ...e,
+    }));
+    if (
+      !agents.length &&
+      !workflows.length &&
+      !sessions.length &&
+      !edits.customer
+    ) {
+      return undefined;
+    }
+    return { agents, workflows, sessions, customer: edits.customer };
+  }, [edits]);
+
   const { workflows } = plan.decisions;
   // Stable identity — FlowMap relayouts when the group-name CONTENT changes.
+  // Detected names on purpose: renaming a workflow decision doesn't rename
+  // the graph's group labels.
   const workflowNames = useMemo(
     () => workflows.map((w) => w.name),
     [workflows]
@@ -80,11 +156,18 @@ export function SetupBoard({
           status={status}
           firstTraceId={firstTraceId}
           failureStage={failureStage}
-          onApprove={onApprove}
+          onApprove={() => onApprove(buildEdits())}
           onReject={onReject}
           approving={approving}
         />
-        <DecisionList plan={plan} onFocus={setFocus} onSelect={selectFocus} />
+        <DecisionList
+          plan={plan}
+          edits={edits}
+          editable={status === "awaiting_approval"}
+          onEdit={applyEdit}
+          onFocus={setFocus}
+          onSelect={selectFocus}
+        />
       </div>
 
       <FlowMap

--- a/apps/web/src/lib/setup-prompt.ts
+++ b/apps/web/src/lib/setup-prompt.ts
@@ -189,7 +189,8 @@ ask the user to tell you when they're done:
 Each request is held open server-side for up to ~9 seconds, so this costs almost
 nothing and returns within a second of the user clicking. What it prints:
 - \`approved\` or \`applying\` — go to step 5. The response carries \`decisions\`
-  (the approved plan), \`sdk\` and \`hasReactUi\`; use those, not your local copy.
+  (the approved plan), \`sdk\` and \`hasReactUi\`; use those, not your local copy —
+  the user may have renamed things or changed id sources on the review page.
 - \`rejected\` — stop. Change nothing. Tell the user their repo is untouched.
 - \`expired\` — the plan timed out. Start again at step 1.
 - nothing at all — the 7-minute bound was hit. Run the exact same command again.

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -11,6 +11,9 @@ export type ActivationEvent =
   // that flips a null timestamp, so reloads and repeated polls can't duplicate.
   | "instrumentation_plan_created"
   | "instrumentation_plan_approved"
+  // Fired alongside _approved when the user changed decisions before
+  // approving — the signal that the editable review earns its keep.
+  | "instrumentation_plan_edited"
   | "instrumentation_agent_resumed"
   | "instrumentation_changes_applied"
   | "instrumentation_waiting_for_trace"

--- a/packages/api/src/routers/instrumentationPlans.ts
+++ b/packages/api/src/routers/instrumentationPlans.ts
@@ -1,3 +1,4 @@
+import { PlanEdits } from "@foglamp/contracts/instrumentation";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
@@ -59,10 +60,28 @@ export const instrumentationPlansRouter = router({
     }),
 
   approve: protectedProcedure
-    .input(z.object({ planId: z.string().min(1).max(64) }))
+    // `edits` is the Stage 2 review surface: renames and source tweaks, merged
+    // onto the DETECTED decisions server-side (see applyPlanEdits).
+    .input(
+      z.object({
+        planId: z.string().min(1).max(64),
+        edits: PlanEdits.optional(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
-      const res = await approvePlan(ctx.db, ctx.session.user.id, input.planId);
+      const res = await approvePlan(
+        ctx.db,
+        ctx.session.user.id,
+        input.planId,
+        input.edits
+      );
       if (!res.ok) {
+        if (res.reason === "invalid") {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `These edits can't be applied: ${res.errors.join("; ")}`,
+          });
+        }
         throw new TRPCError({
           code: res.reason === "not_found" ? "NOT_FOUND" : "CONFLICT",
           message:

--- a/packages/api/src/services/instrumentationPlans.ts
+++ b/packages/api/src/services/instrumentationPlans.ts
@@ -1,9 +1,11 @@
 import { captureActivationEvent } from "@foglamp/analytics";
 import { listTraces } from "@foglamp/clickhouse";
 import {
+  applyPlanEdits,
   canTransition,
   type Decisions,
   type FailureStage,
+  type PlanEdits,
   type PlanStatus,
   summarizePlan,
   validateAppliedReport,
@@ -199,12 +201,20 @@ async function transition(
   return { ok: false, reason: "illegal" };
 }
 
-/** The user approved the plan. Idempotent. */
+export type ApproveOutcome =
+  | TransitionOutcome
+  | { ok: false; reason: "invalid"; errors: string[] };
+
+/**
+ * The user approved the plan, optionally with edits (renames, source tweaks —
+ * see PlanEdits). Idempotent; edits only land on the transition that wins.
+ */
 export async function approvePlan(
   db: Db,
   userId: string,
   planId: string,
-): Promise<TransitionOutcome> {
+  edits?: PlanEdits,
+): Promise<ApproveOutcome> {
   const plan = await getPlanForUser(db, userId, planId);
   if (!plan) return { ok: false, reason: "not_found" };
   // Past the deadline the waiting agent has already given up, so an approval
@@ -212,10 +222,18 @@ export async function approvePlan(
   // that nothing will ever pick up.
   if (effectiveStatus(plan) === "expired") return { ok: false, reason: "illegal" };
 
-  // Stage 1's review UI is read-only, so the approved decisions are the
-  // detected ones. Snapshotting them now means a Stage 2 edit — or a later
-  // contract change — can never retroactively alter what was agreed to.
-  const approved: Decisions = plan.detected.decisions;
+  // The approved decisions are the detected ones with the user's edits merged
+  // on top, server-side — the browser can rename and re-source, never invent
+  // call sites or rewrite the evidence. Snapshotting the merge now means a
+  // later contract change can never retroactively alter what was agreed to.
+  let approved: Decisions = plan.detected.decisions;
+  let editedCount = 0;
+  if (edits) {
+    const merged = applyPlanEdits(plan.detected.decisions, edits);
+    if (!merged.ok) return { ok: false, reason: "invalid", errors: merged.errors };
+    approved = merged.decisions;
+    editedCount = merged.editedCount;
+  }
 
   const res = await transition(db, {
     planId,
@@ -232,7 +250,14 @@ export async function approvePlan(
     void capture("instrumentation_plan_approved", owner, {
       project_id: plan.projectId,
       seconds_to_approval: secondsBetween(plan.createdAt, new Date()),
+      edited_decisions: editedCount,
     });
+    if (editedCount > 0) {
+      void capture("instrumentation_plan_edited", owner, {
+        project_id: plan.projectId,
+        edited_decisions: editedCount,
+      });
+    }
   }
   return res;
 }

--- a/packages/contracts/src/instrumentation.test.ts
+++ b/packages/contracts/src/instrumentation.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  applyPlanEdits,
   canTransition,
   isPending,
   isTerminalStatus,
   PLAN_STATUSES,
   PLAN_VERSION,
+  PlanEdits,
   summarizePlan,
   TERMINAL_STATUSES,
   validateAppliedReport,
@@ -254,5 +256,156 @@ describe("summarizePlan", () => {
       sessions: 0,
       calls: 1,
     });
+  });
+});
+
+describe("applyPlanEdits", () => {
+  // Detected decisions with one of everything editable.
+  const detected = () => {
+    const res = validateDetectedPlan(
+      plan({
+        calls: [
+          { id: "c1", fn: "streamText", sourceRef: "src/agents/support.ts:42" },
+          { id: "c2", fn: "generateText", sourceRef: "src/jobs/digest.ts:10" },
+        ],
+        decisions: {
+          agents: [
+            {
+              id: "a1",
+              name: "support",
+              callIds: ["c1"],
+              confidence: "high" as const,
+              sourceRef: "src/agents/support.ts:42",
+              rationale: "A named streamText loop behind the support route.",
+            },
+          ],
+          workflows: [
+            {
+              id: "w1",
+              name: "Nightly digest",
+              callIds: ["c2"],
+              runIdSource: "the cron invocation id",
+              confidence: "medium" as const,
+              sourceRef: "src/jobs/digest.ts:10",
+              rationale: "A multi-step cron pipeline.",
+            },
+          ],
+          sessions: [
+            {
+              id: "s1",
+              label: "Support chat",
+              callIds: ["c1"],
+              sessionIdSource: "the thread id on the request",
+              confidence: "high" as const,
+              sourceRef: "src/agents/support.ts:42",
+              rationale: "A real back-and-forth thread.",
+            },
+          ],
+          customer: {
+            recommended: false,
+            confidence: "medium" as const,
+            rationale: "Tenancy unclear.",
+          },
+        },
+      }),
+    );
+    if (!res.ok) throw new Error(res.errors.join("; "));
+    return res.data.decisions;
+  };
+  const edits = (over: Record<string, unknown> = {}) =>
+    PlanEdits.parse(over);
+
+  test("no edits is a clean pass-through", () => {
+    const res = applyPlanEdits(detected(), edits());
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.editedCount).toBe(0);
+    expect(res.decisions).toEqual(detected());
+  });
+
+  test("renames apply; evidence fields survive untouched", () => {
+    const res = applyPlanEdits(
+      detected(),
+      edits({
+        agents: [{ id: "a1", name: "Support copilot", oneOff: true }],
+        workflows: [{ id: "w1", runIdSource: "the queue job id" }],
+      }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.editedCount).toBe(2);
+    const agent = res.decisions.agents[0]!;
+    expect(agent.name).toBe("Support copilot");
+    expect(agent.oneOff).toBe(true);
+    expect(agent.callIds).toEqual(["c1"]);
+    expect(agent.rationale).toContain("streamText loop");
+    expect(res.decisions.workflows[0]!.runIdSource).toBe("the queue job id");
+    expect(res.decisions.workflows[0]!.name).toBe("Nightly digest");
+  });
+
+  test("a no-op edit (same values) counts nothing as edited", () => {
+    const res = applyPlanEdits(
+      detected(),
+      edits({ agents: [{ id: "a1", name: "support" }] }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.editedCount).toBe(0);
+  });
+
+  test("whitespace-only names fall back to the detected value", () => {
+    const res = applyPlanEdits(
+      detected(),
+      edits({ agents: [{ id: "a1", name: "   " }] }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.decisions.agents[0]!.name).toBe("support");
+    expect(res.editedCount).toBe(0);
+  });
+
+  test("unknown ids are rejected — you can only edit what was detected", () => {
+    const res = applyPlanEdits(
+      detected(),
+      edits({ agents: [{ id: "ghost", name: "Nope" }] }),
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.errors.join()).toContain('unknown id "ghost"');
+  });
+
+  test("enabling customer attribution requires an id source", () => {
+    const bare = applyPlanEdits(
+      detected(),
+      edits({ customer: { recommended: true } }),
+    );
+    expect(bare.ok).toBe(false);
+    if (!bare.ok) expect(bare.errors.join()).toContain("idSource");
+
+    const withSource = applyPlanEdits(
+      detected(),
+      edits({
+        customer: { recommended: true, idSource: "the org id on the session" },
+      }),
+    );
+    expect(withSource.ok).toBe(true);
+    if (!withSource.ok) return;
+    expect(withSource.editedCount).toBe(1);
+    expect(withSource.decisions.customer.recommended).toBe(true);
+  });
+
+  test("session label and id-source edits apply", () => {
+    const res = applyPlanEdits(
+      detected(),
+      edits({
+        sessions: [
+          { id: "s1", label: "Helpdesk", sessionIdSource: "the chat id" },
+        ],
+      }),
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.decisions.sessions[0]!.label).toBe("Helpdesk");
+    expect(res.decisions.sessions[0]!.sessionIdSource).toBe("the chat id");
   });
 });

--- a/packages/contracts/src/instrumentation.ts
+++ b/packages/contracts/src/instrumentation.ts
@@ -312,6 +312,164 @@ export const ApprovedPlan = z
 export type ApprovedPlan = z.infer<typeof ApprovedPlan>;
 
 // ---------------------------------------------------------------------------
+// PlanEdits — what the review UI may change before approving (Stage 2)
+// ---------------------------------------------------------------------------
+//
+// The browser never sends a whole Decisions object: it sends a small patch
+// keyed by decision id, and the server applies it onto the DETECTED decisions.
+// That keeps callIds, sourceRefs, rationales and confidences server-
+// authoritative — an edited approval can rename things and adjust sources,
+// never invent call sites or rewrite the evidence.
+
+const AgentEdit = z
+  .object({
+    id: z.string().min(1).max(64),
+    name: StaticName.optional(),
+    oneOff: z.boolean().optional(),
+  })
+  .strict();
+
+const WorkflowEdit = z
+  .object({
+    id: z.string().min(1).max(64),
+    name: StaticName.optional(),
+    runIdSource: ValueSource.optional(),
+  })
+  .strict();
+
+const SessionEdit = z
+  .object({
+    id: z.string().min(1).max(64),
+    label: z.string().min(1).max(48).optional(),
+    sessionIdSource: ValueSource.optional(),
+  })
+  .strict();
+
+const CustomerEdit = z
+  .object({
+    recommended: z.boolean().optional(),
+    idSource: ValueSource.optional(),
+  })
+  .strict();
+
+export const PlanEdits = z
+  .object({
+    agents: z.array(AgentEdit).max(40).default([]),
+    workflows: z.array(WorkflowEdit).max(20).default([]),
+    sessions: z.array(SessionEdit).max(20).default([]),
+    customer: CustomerEdit.optional(),
+  })
+  .strict();
+export type PlanEdits = z.infer<typeof PlanEdits>;
+
+export type ApplyEditsResult =
+  | {
+      ok: true;
+      decisions: Decisions;
+      /** Decisions that actually changed — 0 means the edits were all no-ops. */
+      editedCount: number;
+    }
+  | { ok: false; errors: string[] };
+
+/** Trimmed value, or undefined when the edit is absent or trims to nothing —
+ *  an all-whitespace input falls back to the detected value instead of
+ *  producing an empty name. */
+function cleaned(value: string | undefined): string | undefined {
+  const t = value?.trim();
+  return t ? t : undefined;
+}
+
+/**
+ * Apply user edits onto the detected decisions, producing what the agent will
+ * receive. Pure. Unknown ids are errors (the UI can only edit what was
+ * detected); the merged result is re-validated through `Decisions`, so caps
+ * and the customer `recommended → idSource` invariant hold no matter what the
+ * browser sent.
+ */
+export function applyPlanEdits(
+  detected: Decisions,
+  edits: PlanEdits,
+): ApplyEditsResult {
+  const errors: string[] = [];
+  let editedCount = 0;
+
+  function mergeList<
+    T extends { id: string },
+    E extends { id: string },
+  >(
+    kind: string,
+    list: T[],
+    patches: E[],
+    apply: (item: T, patch: E) => T,
+  ): T[] {
+    const byId = new Map(list.map((d) => [d.id, d] as const));
+    for (const patch of patches) {
+      const cur = byId.get(patch.id);
+      if (!cur) {
+        errors.push(`decisions.${kind}: unknown id "${patch.id}"`);
+        continue;
+      }
+      const next = apply(cur, patch);
+      if (JSON.stringify(next) !== JSON.stringify(cur)) {
+        editedCount += 1;
+        byId.set(patch.id, next);
+      }
+    }
+    return list.map((d) => byId.get(d.id)!);
+  }
+
+  const agents = mergeList(
+    "agents",
+    detected.agents,
+    edits.agents,
+    (a, e) => ({
+      ...a,
+      name: cleaned(e.name) ?? a.name,
+      oneOff: e.oneOff ?? a.oneOff,
+    }),
+  );
+  const workflows = mergeList(
+    "workflows",
+    detected.workflows,
+    edits.workflows,
+    (w, e) => ({
+      ...w,
+      name: cleaned(e.name) ?? w.name,
+      runIdSource: cleaned(e.runIdSource) ?? w.runIdSource,
+    }),
+  );
+  const sessions = mergeList(
+    "sessions",
+    detected.sessions,
+    edits.sessions,
+    (s, e) => ({
+      ...s,
+      label: cleaned(e.label) ?? s.label,
+      sessionIdSource: cleaned(e.sessionIdSource) ?? s.sessionIdSource,
+    }),
+  );
+
+  let customer = detected.customer;
+  if (edits.customer) {
+    const next = {
+      ...customer,
+      recommended: edits.customer.recommended ?? customer.recommended,
+      idSource: cleaned(edits.customer.idSource) ?? customer.idSource,
+    };
+    if (JSON.stringify(next) !== JSON.stringify(customer)) {
+      editedCount += 1;
+      customer = next;
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  const parsed = Decisions.safeParse({ agents, workflows, sessions, customer });
+  if (!parsed.success) return { ok: false, errors: flatten(parsed.error.issues) };
+  return { ok: true, decisions: parsed.data, editedCount };
+}
+
+// ---------------------------------------------------------------------------
 // AppliedReport — what the agent uploads after editing the repo
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

The review page's decisions are now editable before approving. While a plan is awaiting approval, every row grows an inline editor (pencil on hover):

- **Agents** — rename, toggle one-off trace (switch)
- **Workflows** — rename, edit the run-id source
- **Conversations** — rename the label, edit the thread-id source
- **Customer attribution** — flip on/off, set the customer-id source

Edited rows show an "edited" badge with a Reset; clearing a field falls back to the detected value. Real agent loops carry an orange "Agent loop" tag beside the name (one-offs are the quiet default).

## How

- The browser sends a **patch-by-id `PlanEdits` object**, never a whole decisions blob. The server merges it onto the DETECTED decisions (`applyPlanEdits` in contracts), so `callIds`, `rationale`, `confidence`, and `sourceRef` stay server-authoritative, then re-validates with the full `Decisions` schema (caps + the customer id-source refine).
- The merged result is snapshotted into the `approved` column — the agent's long-poll already reads that column, so edits reach the coding agent with **zero agent-side changes**. Unknown ids and invalid combinations come back as `BAD_REQUEST` with the reasons.
- Approving with real changes fires `instrumentation_plan_edited` (with an `edited_decisions` count) alongside `_approved`, both structurally deduped by the conditional status transition.
- Perf: the hover-spotlight commit is debounced 90ms so scrolling the list no longer re-renders the map once per row; text edits commit on blur/Enter, not per keystroke.

## Tests

- 7 new `applyPlanEdits` contract tests (renames, no-op detection, unknown-id rejection, whitespace fallback, customer id-source requirement) — 31 pass total
- `bun check-types` clean across the workspace; web `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GeaghbuAYppc2MgNsPkMw4