### PR TITLE
Stage 3: verification report + opt-in public share

### DIFF
--- a/apps/web/src/app/setup/[planId]/setup-client.tsx
+++ b/apps/web/src/app/setup/[planId]/setup-client.tsx
@@ -45,7 +45,10 @@ function readStoredShare(planId: string): StoredShare | null {
     const raw = localStorage.getItem(shareStorageKey(planId));
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<StoredShare>;
-    if (typeof parsed.slug !== "string" || typeof parsed.editToken !== "string") {
+    if (
+      typeof parsed.slug !== "string" ||
+      typeof parsed.editToken !== "string"
+    ) {
       return null;
     }
     return { slug: parsed.slug, editToken: parsed.editToken };
@@ -137,10 +140,7 @@ export function SetupClient({ planId }: { planId: string }) {
         const stored = { slug: res.slug, editToken: res.editToken };
         setShare(stored);
         try {
-          localStorage.setItem(
-            shareStorageKey(planId),
-            JSON.stringify(stored)
-          );
+          localStorage.setItem(shareStorageKey(planId), JSON.stringify(stored));
         } catch {
           // Storage disabled — the share still worked, a re-share just mints
           // a fresh URL instead of updating this one.
@@ -205,19 +205,16 @@ export function SetupClient({ planId }: { planId: string }) {
         onReject={() => reject.mutate({ planId })}
         approving={approve.isPending || reject.isPending}
         shareSlug={share?.slug ?? null}
-        onShare={() =>
-          shareMap.mutate({ planId, editToken: share?.editToken })
-        }
+        onShare={() => shareMap.mutate({ planId, editToken: share?.editToken })}
         sharing={shareMap.isPending}
       />
       <Dialog open={approvedOpen} onOpenChange={setApprovedOpen}>
         <DialogContent className="sm:max-w-sm">
           <DialogHeader>
-            <DialogTitle>Approved — you're done here</DialogTitle>
+            <DialogTitle>Approved</DialogTitle>
             <DialogDescription>
               Your coding agent picked the plan up and is implementing the
-              instrumentation on its own. You can close this tab — or keep it
-              open to watch your first trace land.
+              instrumentation.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/apps/web/src/app/setup/[planId]/setup-client.tsx
+++ b/apps/web/src/app/setup/[planId]/setup-client.tsx
@@ -28,6 +28,32 @@ import { trpc } from "@/utils/trpc";
 /** How often to re-read the plan while it can still change. */
 const POLL_MS = 2_000;
 
+/**
+ * Where a plan's public-share credentials live in localStorage. Keeping the
+ * editToken client-side (keyed by plan) is what makes "Share" idempotent: a
+ * re-share updates the same /scan slug instead of minting a new URL.
+ */
+const shareStorageKey = (planId: string) => `foglamp.setup.share.${planId}`;
+
+interface StoredShare {
+  slug: string;
+  editToken: string;
+}
+
+function readStoredShare(planId: string): StoredShare | null {
+  try {
+    const raw = localStorage.getItem(shareStorageKey(planId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredShare>;
+    if (typeof parsed.slug !== "string" || typeof parsed.editToken !== "string") {
+      return null;
+    }
+    return { slug: parsed.slug, editToken: parsed.editToken };
+  } catch {
+    return null;
+  }
+}
+
 export function SetupClient({ planId }: { planId: string }) {
   const qc = useQueryClient();
   const queryKey = trpc.instrumentationPlans.get.queryKey({ planId });
@@ -94,6 +120,41 @@ export function SetupClient({ planId }: { planId: string }) {
     })
   );
 
+  // The opt-in public share of the instrumented map. Deliberately not part of
+  // the plan row: the credentials are the same anonymous-scan editToken the
+  // /scan lead magnet uses, held only in this browser.
+  const [share, setShare] = useState<StoredShare | null>(null);
+  useEffect(() => {
+    setShare(readStoredShare(planId));
+  }, [planId]);
+
+  const shareMap = useMutation(
+    trpc.instrumentationPlans.share.mutationOptions({
+      onSuccess: (res) => {
+        captureActivationEvent("instrumentation_map_shared", {
+          updated: res.updated,
+        });
+        const stored = { slug: res.slug, editToken: res.editToken };
+        setShare(stored);
+        try {
+          localStorage.setItem(
+            shareStorageKey(planId),
+            JSON.stringify(stored)
+          );
+        } catch {
+          // Storage disabled — the share still worked, a re-share just mints
+          // a fresh URL instead of updating this one.
+        }
+        const url = `${window.location.origin}/scan/${res.slug}`;
+        void navigator.clipboard
+          .writeText(url)
+          .then(() => toast.success("Public map link copied"))
+          .catch(() => toast.success("Public map published"));
+      },
+      onError: (e) => toast.error(e.message),
+    })
+  );
+
   const reject = useMutation(
     trpc.instrumentationPlans.reject.mutationOptions({
       onSuccess: async () => {
@@ -143,6 +204,11 @@ export function SetupClient({ planId }: { planId: string }) {
         onApprove={(edits) => approve.mutate({ planId, edits })}
         onReject={() => reject.mutate({ planId })}
         approving={approve.isPending || reject.isPending}
+        shareSlug={share?.slug ?? null}
+        onShare={() =>
+          shareMap.mutate({ planId, editToken: share?.editToken })
+        }
+        sharing={shareMap.isPending}
       />
       <Dialog open={approvedOpen} onOpenChange={setApprovedOpen}>
         <DialogContent className="sm:max-w-sm">

--- a/apps/web/src/app/setup/[planId]/setup-client.tsx
+++ b/apps/web/src/app/setup/[planId]/setup-client.tsx
@@ -133,8 +133,12 @@ export function SetupClient({ planId }: { planId: string }) {
     <>
       <SetupBoard
         plan={data.detected}
+        approved={data.approved}
+        applied={data.applied}
         status={data.status}
         firstTraceId={data.firstTraceId}
+        spanCount={data.spanCount}
+        secondsToFirstTrace={data.secondsToFirstTrace}
         failureStage={data.failureStage}
         onApprove={(edits) => approve.mutate({ planId, edits })}
         onReject={() => reject.mutate({ planId })}

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import type {
-  Confidence,
-  Decisions,
-} from "@foglamp/contracts/instrumentation";
+import type { Confidence, Decisions } from "@foglamp/contracts/instrumentation";
 import { Card, CardContent } from "@foglamp/ui/components/card";
 import { Input } from "@foglamp/ui/components/input";
 import { Switch } from "@foglamp/ui/components/switch";
@@ -40,16 +37,13 @@ function ConfidenceDot({ level }: { level: Confidence }) {
   return (
     <span
       className={cn(
-        "flex shrink-0 items-center gap-1 text-[10px]",
+        "size-1.5 rounded-full bg-current mt-0.5",
         level === "medium"
           ? "text-amber-600 dark:text-amber-400"
           : "text-muted-foreground"
       )}
       title={`${level} confidence`}
-    >
-      <span className="size-1.5 rounded-full bg-current" />
-      {level}
-    </span>
+    />
   );
 }
 
@@ -211,7 +205,7 @@ function Row({
       onClick={clickable ? () => onSelect(entry.focus!) : undefined}
     >
       <div className="flex items-center justify-between gap-3">
-        <span className="flex min-w-0 items-baseline gap-1.5">
+        <span className="flex min-w-0 items-center gap-1.5">
           <span className="truncate text-[13px]">{entry.name}</span>
           {entry.tag ? (
             <span
@@ -223,6 +217,7 @@ function Row({
               {entry.tag.text}
             </span>
           ) : null}
+          <ConfidenceDot level={entry.confidence} />
           {entry.edited ? (
             <span
               className="shrink-0 text-[11px] font-medium text-sky-600 dark:text-sky-400"
@@ -233,7 +228,6 @@ function Row({
           ) : null}
         </span>
         <span className="flex shrink-0 items-center gap-2">
-          <ConfidenceDot level={entry.confidence} />
           {canEdit ? (
             <button
               type="button"

--- a/apps/web/src/components/setup/decision-list.tsx
+++ b/apps/web/src/components/setup/decision-list.tsx
@@ -2,7 +2,7 @@
 
 import type {
   Confidence,
-  DetectedPlan,
+  Decisions,
 } from "@foglamp/contracts/instrumentation";
 import { Card, CardContent } from "@foglamp/ui/components/card";
 import { Input } from "@foglamp/ui/components/input";
@@ -356,14 +356,15 @@ function isEdited<T>(override: T | undefined, detected: T): boolean {
 // list that's being hovered. Edit commits DO re-render it (the `edits` prop
 // changes), which is the point.
 export const DecisionList = memo(function DecisionList({
-  plan,
+  decisions,
   edits,
   editable,
   onEdit,
   onFocus,
   onSelect,
 }: {
-  plan: DetectedPlan;
+  /** What to render: detected pre-approval, the approved merge after. */
+  decisions: Decisions;
   edits: EditsState;
   /** Rows accept changes only while the plan is awaiting approval. */
   editable: boolean;
@@ -372,7 +373,7 @@ export const DecisionList = memo(function DecisionList({
   /** Click-to-focus: fly the map to the row's subject. */
   onSelect?: (focus: NonNullable<SetupFocus>) => void;
 }) {
-  const { agents, workflows, sessions, customer } = plan.decisions;
+  const { agents, workflows, sessions, customer } = decisions;
   const customerOn = eff(edits.customer?.recommended, customer.recommended);
   const customerIdSource = eff(edits.customer?.idSource, customer.idSource);
 

--- a/apps/web/src/components/setup/setup-board.tsx
+++ b/apps/web/src/components/setup/setup-board.tsx
@@ -71,6 +71,9 @@ export function SetupBoard({
   onApprove,
   onReject,
   approving,
+  shareSlug,
+  onShare,
+  sharing,
 }: {
   plan: DetectedPlan;
   /** The decisions actually agreed to (detected + edits), once approved. */
@@ -85,6 +88,10 @@ export function SetupBoard({
   onApprove: (edits: PlanEdits | undefined) => void;
   onReject: () => void;
   approving: boolean;
+  /** The public /scan slug once this plan's map has been shared. */
+  shareSlug?: string | null;
+  onShare?: () => void;
+  sharing?: boolean;
 }) {
   const [focus, setFocusState] = useState<SetupFocus>(null);
   // Spotlighting re-renders the whole map, so hover commits are debounced:
@@ -206,6 +213,9 @@ export function SetupBoard({
             verified={status === "verified"}
             spanCount={spanCount}
             secondsToFirstTrace={secondsToFirstTrace}
+            shareSlug={shareSlug}
+            onShare={onShare}
+            sharing={sharing}
           />
         ) : null}
         <DecisionList

--- a/apps/web/src/components/setup/setup-board.tsx
+++ b/apps/web/src/components/setup/setup-board.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type {
+  AppliedReport,
+  Decisions,
   DetectedPlan,
   PlanEdits,
   PlanStatus,
@@ -18,6 +20,7 @@ import { FlowMap, type MapZoomTarget } from "@/components/scan/flow-map";
 
 import { DecisionList, type EditPatch } from "./decision-list";
 import { SetupSummary } from "./setup-summary";
+import { VerificationReport } from "./verification-report";
 
 // Hovering a decision row spotlights its subject on the map: a single agent
 // by node label, a single workflow by group label.
@@ -58,16 +61,26 @@ const MAP_PADDING = { left: 452, right: 48 };
 
 export function SetupBoard({
   plan,
+  approved,
+  applied,
   status,
   firstTraceId,
+  spanCount,
+  secondsToFirstTrace,
   failureStage,
   onApprove,
   onReject,
   approving,
 }: {
   plan: DetectedPlan;
+  /** The decisions actually agreed to (detected + edits), once approved. */
+  approved?: Decisions | null;
+  /** The agent's after-report, once the plan has been applied. */
+  applied?: AppliedReport | null;
   status: PlanStatus;
   firstTraceId?: string | null;
+  spanCount?: number | null;
+  secondsToFirstTrace?: number | null;
   failureStage?: string | null;
   onApprove: (edits: PlanEdits | undefined) => void;
   onReject: () => void;
@@ -156,14 +169,20 @@ export function SetupBoard({
     return { agents, workflows, sessions, customer: edits.customer };
   }, [edits]);
 
-  const { workflows } = plan.decisions;
+  // Post-approval the source of truth flips: the list shows what was agreed
+  // to (detected + edits), not the raw detection.
+  const decisions = approved ?? plan.decisions;
   // Stable identity — FlowMap relayouts when the group-name CONTENT changes.
-  // Detected names on purpose: renaming a workflow decision doesn't rename
-  // the graph's group labels.
-  const workflowNames = useMemo(
-    () => workflows.map((w) => w.name),
-    [workflows]
-  );
+  // Union of detected and approved names: the before-graph carries detected
+  // group labels, the agent's after-graph carries the (possibly renamed)
+  // approved ones, and matching is by name.
+  const workflowNames = useMemo(() => {
+    const names = new Set(plan.decisions.workflows.map((w) => w.name));
+    for (const w of approved?.workflows ?? []) names.add(w.name);
+    return [...names];
+  }, [plan, approved]);
+  // Once the agent reports back, the map shows the instrumented architecture.
+  const graph = applied?.scan.graph ?? plan.scan.graph;
 
   return (
     <div className="fixed inset-0 overflow-hidden bg-neutral-100 text-foreground dark:bg-background">
@@ -180,8 +199,17 @@ export function SetupBoard({
           onReject={onReject}
           approving={approving}
         />
+        {applied ? (
+          <VerificationReport
+            before={plan.scan}
+            report={applied}
+            verified={status === "verified"}
+            spanCount={spanCount}
+            secondsToFirstTrace={secondsToFirstTrace}
+          />
+        ) : null}
         <DecisionList
-          plan={plan}
+          decisions={decisions}
           edits={edits}
           editable={status === "awaiting_approval"}
           onEdit={applyEdit}
@@ -191,7 +219,7 @@ export function SetupBoard({
       </div>
 
       <FlowMap
-        graph={plan.scan.graph}
+        graph={graph}
         focusKinds={null}
         focusLabels={focus?.type === "agent" ? [focus.name] : null}
         focusGroups={focus?.type === "workflow" ? [focus.name] : null}

--- a/apps/web/src/components/setup/verification-report.tsx
+++ b/apps/web/src/components/setup/verification-report.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import type { AppliedReport } from "@foglamp/contracts/instrumentation";
+import type { ScanData } from "@foglamp/contracts/scan";
+import { Card, CardContent } from "@foglamp/ui/components/card";
+import { cn } from "@foglamp/ui/lib/utils";
+import {
+  IconAlertTriangleFilled,
+  IconCircleCheckFilled,
+  IconEditFilled,
+  IconFileCodeFilled,
+  IconFileDiffFilled,
+  IconMinus,
+  IconPlusFilled,
+} from "@tabler/icons-react";
+import { useMemo, useState } from "react";
+
+import { diffScans } from "@/components/scan/diff";
+import { KIND_STYLES } from "@/components/scan/kinds";
+
+// The Stage 3 payoff: once the agent has applied the plan, the review page
+// stops being a promise and becomes a receipt. This card renders the agent's
+// AppliedReport — instrumentation coverage, what moved on the map (before
+// scan vs after scan), which files were touched, and anything the agent
+// flagged. Same card anatomy as the decision list: sections inside one
+// scrolling content area.
+
+/** Entries shown per foldable list before "Show N more". */
+const SHOWN = 4;
+
+function Section({
+  label,
+  Icon,
+  iconClassName,
+  children,
+}: {
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  iconClassName?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-5 px-1 first:mt-1">
+      <h2 className="mb-2.5 ml-px flex items-center gap-2 text-[13px] text-muted-foreground">
+        <Icon className={cn("size-3.5 mb-px", iconClassName)} />
+        <span className="leading-none font-medium text-foreground">
+          {label}
+        </span>
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+/** A list that folds behind "Show N more" past the first few entries. */
+function Foldable<T>({
+  items,
+  render,
+}: {
+  items: T[];
+  render: (item: T, i: number) => React.ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const shown = expanded ? items : items.slice(0, SHOWN);
+  const hidden = items.length - shown.length;
+  return (
+    <>
+      <ul className="flex list-none flex-col gap-1">{shown.map(render)}</ul>
+      {hidden > 0 ? (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="mt-2 text-[11px] font-medium cursor-pointer text-muted-foreground/50 hover:text-foreground"
+        >
+          Show {hidden} more
+        </button>
+      ) : null}
+    </>
+  );
+}
+
+export function VerificationReport({
+  before,
+  report,
+  verified,
+  spanCount,
+  secondsToFirstTrace,
+}: {
+  /** The scan the plan was approved against — the "before" of the diff. */
+  before: ScanData;
+  report: AppliedReport;
+  verified: boolean;
+  spanCount?: number | null;
+  secondsToFirstTrace?: number | null;
+}) {
+  const diff = useMemo(() => diffScans(report.scan, before), [report, before]);
+  const instrumented = report.calls.filter((c) => c.instrumented).length;
+  const skipped = report.calls.filter((c) => !c.instrumented);
+
+  return (
+    <Card className="flex max-h-[45%] shrink-0 flex-col overflow-hidden rounded-[36px] squircle:rounded-[36px] py-0">
+      <CardContent className="scroll-fade no-scrollbar flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-5 pb-8">
+        <Section
+          label="What your agent did"
+          Icon={IconCircleCheckFilled}
+          iconClassName="text-emerald-500"
+        >
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            Instrumented {instrumented} of {report.calls.length} model calls
+            {report.hudEnabled ? ", and enabled the dev HUD" : ""}.
+            {verified && spanCount
+              ? ` Your first trace landed${
+                  secondsToFirstTrace
+                    ? ` ${formatSeconds(secondsToFirstTrace)} later`
+                    : ""
+                } with ${spanCount} ${spanCount === 1 ? "span" : "spans"}.`
+              : ""}
+          </p>
+          {skipped.length > 0 ? (
+            <ul className="mt-2 flex list-none flex-col gap-1">
+              {skipped.map((c) => (
+                <li
+                  key={c.id}
+                  className="text-[11px] leading-relaxed text-muted-foreground"
+                >
+                  <span className="text-amber-600 dark:text-amber-400">
+                    Skipped
+                  </span>{" "}
+                  {c.note ?? c.id}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </Section>
+
+        {diff.hasChanges ? (
+          <Section
+            label="On the map"
+            Icon={IconFileDiffFilled}
+            iconClassName="text-muted-foreground"
+          >
+            <Foldable
+              items={[
+                ...diff.addedNodes.map((n) => ({ n, change: "added" as const })),
+                ...diff.changedNodes.map((n) => ({
+                  n,
+                  change: "changed" as const,
+                })),
+                ...diff.removedNodes.map((n) => ({
+                  n,
+                  change: "removed" as const,
+                })),
+              ]}
+              render={({ n, change }) => (
+                <li
+                  key={`${change}:${n.id}`}
+                  className="flex items-center gap-2"
+                >
+                  {change === "added" ? (
+                    <IconPlusFilled className="size-3 flex-none text-green-600 dark:text-green-400" />
+                  ) : change === "changed" ? (
+                    <IconEditFilled className="size-3 flex-none text-yellow-600 dark:text-yellow-400" />
+                  ) : (
+                    <IconMinus className="size-3 flex-none text-red-600 dark:text-red-400" />
+                  )}
+                  <span
+                    className={cn(
+                      "truncate text-[12px]",
+                      change === "removed" &&
+                        "text-muted-foreground line-through"
+                    )}
+                  >
+                    {n.label}
+                  </span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground">
+                    {change === "changed"
+                      ? "updated"
+                      : KIND_STYLES[n.kind].label.toLowerCase()}
+                  </span>
+                </li>
+              )}
+            />
+          </Section>
+        ) : null}
+
+        {report.filesChanged.length > 0 ? (
+          <Section
+            label={`Files changed · ${report.filesChanged.length}`}
+            Icon={IconFileCodeFilled}
+            iconClassName="text-muted-foreground"
+          >
+            <Foldable
+              items={report.filesChanged}
+              render={(path) => (
+                <li
+                  key={path}
+                  className="truncate font-mono text-[10px] text-muted-foreground"
+                  title={path}
+                >
+                  {path}
+                </li>
+              )}
+            />
+          </Section>
+        ) : null}
+
+        {report.warnings.length > 0 ? (
+          <Section
+            label="Heads up"
+            Icon={IconAlertTriangleFilled}
+            iconClassName="text-amber-500"
+          >
+            <ul className="flex list-none flex-col gap-1.5">
+              {report.warnings.map((w) => (
+                <li
+                  key={w}
+                  className="text-[11px] leading-relaxed text-muted-foreground"
+                >
+                  {w}
+                </li>
+              ))}
+            </ul>
+          </Section>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatSeconds(s: number): string {
+  if (s < 90) return `${Math.round(s)}s`;
+  if (s < 5400) return `${Math.round(s / 60)}min`;
+  return `${Math.round(s / 3600)}h`;
+}

--- a/apps/web/src/components/setup/verification-report.tsx
+++ b/apps/web/src/components/setup/verification-report.tsx
@@ -2,6 +2,7 @@
 
 import type { AppliedReport } from "@foglamp/contracts/instrumentation";
 import type { ScanData } from "@foglamp/contracts/scan";
+import { Button } from "@foglamp/ui/components/button";
 import { Card, CardContent } from "@foglamp/ui/components/card";
 import { cn } from "@foglamp/ui/lib/utils";
 import {
@@ -12,6 +13,7 @@ import {
   IconFileDiffFilled,
   IconMinus,
   IconPlusFilled,
+  IconWorldShare,
 } from "@tabler/icons-react";
 import { useMemo, useState } from "react";
 
@@ -85,6 +87,9 @@ export function VerificationReport({
   verified,
   spanCount,
   secondsToFirstTrace,
+  shareSlug,
+  onShare,
+  sharing,
 }: {
   /** The scan the plan was approved against — the "before" of the diff. */
   before: ScanData;
@@ -92,6 +97,10 @@ export function VerificationReport({
   verified: boolean;
   spanCount?: number | null;
   secondsToFirstTrace?: number | null;
+  /** Public /scan slug once shared; the footer flips from ask to link. */
+  shareSlug?: string | null;
+  onShare?: () => void;
+  sharing?: boolean;
 }) {
   const diff = useMemo(() => diffScans(report.scan, before), [report, before]);
   const instrumented = report.calls.filter((c) => c.instrumented).length;
@@ -223,6 +232,47 @@ export function VerificationReport({
           </Section>
         ) : null}
       </CardContent>
+
+      {onShare ? (
+        <div className="flex shrink-0 items-center justify-between gap-3 border-t px-5 py-3">
+          {shareSlug ? (
+            <>
+              <a
+                href={`/scan/${encodeURIComponent(shareSlug)}`}
+                target="_blank"
+                rel="noreferrer"
+                className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium hover:underline"
+              >
+                <IconWorldShare className="size-3.5 flex-none text-muted-foreground" />
+                <span className="truncate">View your public map</span>
+              </a>
+              <button
+                type="button"
+                onClick={onShare}
+                disabled={sharing}
+                className="shrink-0 cursor-pointer text-[11px] font-medium text-muted-foreground/60 hover:text-foreground disabled:cursor-default"
+              >
+                {sharing ? "Updating…" : "Update"}
+              </button>
+            </>
+          ) : (
+            <>
+              <p className="text-[11px] leading-snug text-muted-foreground">
+                Share a public, read-only map — structure only, never code.
+              </p>
+              <Button
+                size="sm"
+                variant="secondary"
+                className="shrink-0"
+                onClick={onShare}
+                disabled={sharing}
+              >
+                {sharing ? "Sharing…" : "Share"}
+              </Button>
+            </>
+          )}
+        </div>
+      ) : null}
     </Card>
   );
 }

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -11,7 +11,8 @@ type ClientActivationEvent =
   // of the funnel is captured server-side (@foglamp/analytics), since it's
   // driven by the user's coding agent.
   | "instrumentation_plan_viewed"
-  | "instrumentation_plan_approved";
+  | "instrumentation_plan_approved"
+  | "instrumentation_map_shared";
 
 export function captureActivationEvent(
   event: ClientActivationEvent,

--- a/packages/api/src/routers/instrumentationPlans.ts
+++ b/packages/api/src/routers/instrumentationPlans.ts
@@ -10,6 +10,7 @@ import {
   rejectPlan,
   verifyFirstTrace,
 } from "../services/instrumentationPlans";
+import { claimScan, createOrUpdateScan } from "../services/scans";
 
 // The browser half of the onboarding approval loop. The agent half is a set of
 // API-key-authed REST routes in apps/server/src/instrumentation.ts — the two
@@ -94,6 +95,60 @@ export const instrumentationPlansRouter = router({
         });
       }
       return { status: res.row.status };
+    }),
+
+  /**
+   * The explicit, opt-in public share (Stage 3, part 2). Publishes the agent's
+   * after-scan — already a validated, sanitized `ScanData`, the exact contract
+   * the anonymous /scan lead magnet uses, so nothing beyond structured
+   * metadata can leave — as a public scan page. Re-sharing with the editToken
+   * from a previous share updates the same slug instead of minting a new URL.
+   */
+  share: protectedProcedure
+    .input(
+      z.object({
+        planId: z.string().min(1).max(64),
+        editToken: z.string().min(1).max(128).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const plan = await getPlanForUser(
+        ctx.db,
+        ctx.session.user.id,
+        input.planId
+      );
+      if (!plan) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Plan not found" });
+      }
+      if (!plan.applied) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "There's nothing to share until your agent applies the plan",
+        });
+      }
+      const outcome = await createOrUpdateScan(ctx.db, {
+        data: plan.applied.scan,
+        editToken: input.editToken,
+      });
+      if (!outcome.ok) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `This map can't be shared: ${outcome.errors.join("; ")}`,
+        });
+      }
+      // Claim it for the sharer right away: a map published from a signed-in
+      // setup shouldn't self-destruct on the anonymous 90-day TTL. Best-effort
+      // — the share itself already succeeded.
+      await claimScan(ctx.db, {
+        slug: outcome.result.slug,
+        editToken: outcome.result.editToken,
+        userId: ctx.session.user.id,
+      });
+      return {
+        slug: outcome.result.slug,
+        editToken: outcome.result.editToken,
+        updated: outcome.result.updated,
+      };
     }),
 
   reject: protectedProcedure

--- a/packages/api/src/routers/instrumentationPlans.ts
+++ b/packages/api/src/routers/instrumentationPlans.ts
@@ -46,6 +46,9 @@ export const instrumentationPlansRouter = router({
           expiresAt: plan.expiresAt,
         }),
         detected: plan.detected,
+        // The decisions that were actually agreed to (detected + user edits).
+        // Post-approval surfaces render these, not the detected originals.
+        approved: plan.approved,
         applied: plan.applied,
         failureStage: plan.failureStage,
         expiresAt: plan.expiresAt,


### PR DESCRIPTION
The review page's third act. Once the coding agent applies the plan, the page stops being a promise and becomes a receipt — and, if the user wants, a shareable one.

## Part 1 — verification report (`76e2359`)

- `instrumentationPlans.get` now returns `approved` and `applied` alongside `detected`.
- Post-approval, the decision list renders the **agreed** decisions (detected + edits), closing self-review finding 3 from #79; the map flips to the agent's after-graph once applied.
- New `VerificationReport` card: instrumentation coverage (with skipped calls + notes), a before/after map diff via the existing `diffScans`, files changed, and agent warnings — foldable lists past 4 entries. Verified plans get the first-trace timing sentence.
- `workflowNames` passed to the map is the union of detected + approved names, since the after-graph may carry renamed groups.

## Part 2 — opt-in public share (`defb8b7`)

- New `instrumentationPlans.share` protected mutation: requires the plan to be applied, then publishes `applied.scan` through the **existing anonymous-scan pipeline** — `createOrUpdateScan` re-validates the sanitized `ScanData` contract server-side, so only structured metadata can leave (the Scan security model is untouched). The scan is claimed for the sharer so it never expires.
- The browser keeps the returned `editToken` in localStorage keyed by plan id, so re-sharing **updates the same `/scan` slug** instead of minting a new URL.
- The verification report grows a footer: "Share a public, read-only map — structure only, never code" with a Share button; once shared, a link to the public map plus an Update action. Link is copied to the clipboard on success.
- Client analytics: `instrumentation_map_shared`.

Sharing is strictly opt-in per the spec — nothing is published without the click.

## Verification

- `bun test packages/contracts/src/instrumentation.test.ts` — 31 pass
- `apps/web` tsc — clean
- `bun check-types` — 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V79vCcngLWPL1XE8bGAQ6V