### PR TITLE
Reject degenerate architecture maps at plan upload

### DIFF
--- a/apps/web/src/lib/setup-prompt.ts
+++ b/apps/web/src/lib/setup-prompt.ts
@@ -135,6 +135,18 @@ Workflows are groups, never nodes:
   member nodes, set to that workflow decision's EXACT name ("Nightly digest" —
   never the literal word "workflow"). The review map draws matching groups as
   labeled workflow boxes and spotlights them from the decision list.
+
+Before you write the plan file, AUDIT your map against this checklist. The
+server runs the same checks and rejects a failing upload with 422:
+- [ ] At least one "model" node, one per distinct model the calls use.
+- [ ] Not just agents: the services, stores and third-party APIs the flows
+      touch are on the map. A map that is >80% agent nodes is rejected.
+- [ ] Entry points are concrete routes / pages / webhooks / crons — at least
+      one "entry" or "cron" node, and never a single generic hub.
+- [ ] Every agent node has edges: FROM its trigger, TO what it uses. A map
+      with fewer edges than half its nodes is rejected.
+- [ ] Trace one real request end to end (entry -> agent -> model/tool -> store)
+      and check the map shows that path. If it doesn't, redo the map.
 ${SCAN_SHAPE}
 
 ${SCAN_RULES}

--- a/packages/api/src/services/instrumentationPlans.ts
+++ b/packages/api/src/services/instrumentationPlans.ts
@@ -2,6 +2,7 @@ import { captureActivationEvent } from "@foglamp/analytics";
 import { listTraces } from "@foglamp/clickhouse";
 import {
   applyPlanEdits,
+  auditPlanGraph,
   canTransition,
   type Decisions,
   type FailureStage,
@@ -78,6 +79,11 @@ export async function createPlan(
 ): Promise<PlanCreateOutcome> {
   const parsed = validateDetectedPlan(input.detected);
   if (!parsed.ok) return { ok: false, errors: parsed.errors };
+
+  // Schema-valid but degenerate maps (all agent nodes, no wiring) are bounced
+  // too — the 422 details tell the agent exactly what the picture is missing.
+  const audit = auditPlanGraph(parsed.data);
+  if (audit.length > 0) return { ok: false, errors: audit };
 
   const expiresAt = new Date(Date.now() + PLAN_TTL_HOURS * 3_600_000);
   const rows = await db

--- a/packages/contracts/src/instrumentation.test.ts
+++ b/packages/contracts/src/instrumentation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   applyPlanEdits,
+  auditPlanGraph,
   canTransition,
   isPending,
   isTerminalStatus,
@@ -256,6 +257,92 @@ describe("summarizePlan", () => {
       sessions: 0,
       calls: 1,
     });
+  });
+});
+
+describe("auditPlanGraph", () => {
+  // Build a plan around an arbitrary graph; decisions/calls come from the
+  // shared fixture (1 call), which is what makes the model-node check apply.
+  const withGraph = (
+    nodes: { id: string; label: string; kind: string }[],
+    edges: { from: string; to: string }[],
+  ) => {
+    const res = validateDetectedPlan(plan({ scan: { ...scan, graph: { nodes, edges } } }));
+    if (!res.ok) throw new Error(res.errors.join("; "));
+    return res.data;
+  };
+  const agents = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `a${i}`,
+      label: `Agent ${i}`,
+      kind: "agent",
+    }));
+
+  test("passes a small honest map", () => {
+    const p = withGraph(
+      [
+        { id: "e", label: "POST /api/chat", kind: "entry" },
+        { id: "a0", label: "Support agent", kind: "agent" },
+        { id: "m", label: "GPT-4o", kind: "model" },
+      ],
+      [
+        { from: "e", to: "a0" },
+        { from: "a0", to: "m" },
+      ],
+    );
+    expect(auditPlanGraph(p)).toEqual([]);
+  });
+
+  test("stays lenient below the size thresholds", () => {
+    // Tiny map: no entry node and no edges, but it does name the model.
+    const p = withGraph(
+      [
+        { id: "a0", label: "Classifier", kind: "agent" },
+        { id: "m", label: "GPT-4o-mini", kind: "model" },
+      ],
+      [],
+    );
+    expect(auditPlanGraph(p)).toEqual([]);
+  });
+
+  test("rejects a map with calls but no model nodes", () => {
+    const p = withGraph(agents(1), []);
+    expect(auditPlanGraph(p).join()).toContain("no model nodes");
+  });
+
+  test("rejects the decisions-list-re-drawn shape", () => {
+    // 9 agents + 1 model: 90% agents, sparse, no entries, stranded — the
+    // exact degenerate map that motivated the audit fires every check.
+    const p = withGraph(
+      [...agents(9), { id: "m", label: "GPT-4o", kind: "model" }],
+      [],
+    );
+    const errors = auditPlanGraph(p).join();
+    expect(errors).toContain("nodes are agents");
+    expect(errors).toContain("floats unconnected");
+    expect(errors).toContain("no edges at all");
+    expect(errors).toContain("no entry or cron nodes");
+  });
+
+  test("passes a well-wired map of the same size", () => {
+    // Same 10 subjects drawn honestly: entry, chained agents, shared model.
+    const nodes = [
+      { id: "e", label: "POST /api/run", kind: "entry" },
+      ...agents(4),
+      { id: "s", label: "Billing service", kind: "service" },
+      { id: "db", label: "Postgres", kind: "store" },
+      { id: "m", label: "GPT-4o", kind: "model" },
+    ];
+    const edges = [
+      { from: "e", to: "a0" },
+      { from: "a0", to: "a1" },
+      { from: "a1", to: "a2" },
+      { from: "a2", to: "a3" },
+      { from: "a3", to: "m" },
+      { from: "a0", to: "s" },
+      { from: "s", to: "db" },
+    ];
+    expect(auditPlanGraph(withGraph(nodes, edges))).toEqual([]);
   });
 });
 

--- a/packages/contracts/src/instrumentation.ts
+++ b/packages/contracts/src/instrumentation.ts
@@ -23,7 +23,7 @@
 
 import { z } from "zod";
 
-import { ScanData } from "./scan";
+import { type GraphNode, ScanData } from "./scan";
 
 /** Schema version for the plan payloads, independent of ScanData's version. */
 export const PLAN_VERSION = 1;
@@ -536,6 +536,63 @@ export function validateAppliedReport(
   const res = AppliedReport.safeParse(input);
   if (res.success) return { ok: true, data: res.data };
   return { ok: false, errors: flatten(res.error.issues) };
+}
+
+// ---------------------------------------------------------------------------
+// Graph audit — degenerate-map detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural sanity checks on the architecture map, beyond what the schema can
+ * express. A graph that is just the decisions list re-drawn — all agent nodes,
+ * barely any wiring, no models or stores — defeats the review page: the user
+ * can't judge a plan against a picture that isn't their system. These lines
+ * join the 422 `details` on upload, so the agent self-corrects and retries.
+ *
+ * Thresholds are deliberately loose: a tiny repo with two agents and a route
+ * passes untouched. Only maps that are BOTH sizable and degenerate fail.
+ */
+export function auditPlanGraph(plan: DetectedPlan): string[] {
+  const { nodes, edges } = plan.scan.graph;
+  const errors: string[] = [];
+  const ofKind = (kind: GraphNode["kind"]) =>
+    nodes.filter((n) => n.kind === kind);
+
+  if (plan.calls.length > 0 && ofKind("model").length === 0) {
+    errors.push(
+      "scan.graph: no model nodes — add one model node per distinct model the calls use, wired from the agents that call it",
+    );
+  }
+
+  const agents = ofKind("agent");
+  if (nodes.length >= 8 && agents.length / nodes.length > 0.8) {
+    errors.push(
+      `scan.graph: ${agents.length} of ${nodes.length} nodes are agents — this is the decisions list re-drawn, not the architecture; add the models, services, stores and third-party APIs the flows touch`,
+    );
+  }
+
+  if (nodes.length >= 6 && edges.length * 2 < nodes.length) {
+    errors.push(
+      `scan.graph: only ${edges.length} edges for ${nodes.length} nodes — most of the map floats unconnected; wire each flow end to end, entry through model`,
+    );
+  }
+
+  if (nodes.length >= 6) {
+    const connected = new Set(edges.flatMap((e) => [e.from, e.to]));
+    const stranded = agents.filter((n) => !connected.has(n.id));
+    if (agents.length >= 3 && stranded.length * 2 > agents.length) {
+      errors.push(
+        `scan.graph: ${stranded.length} of ${agents.length} agent nodes have no edges at all — connect each agent FROM what triggers it and TO what it uses`,
+      );
+    }
+    if (ofKind("entry").length === 0 && ofKind("cron").length === 0) {
+      errors.push(
+        "scan.graph: no entry or cron nodes — add the real routes, pages, webhooks or scheduled jobs that trigger the AI work",
+      );
+    }
+  }
+
+  return errors;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
A real uploaded plan rendered as the decisions list re-drawn — 29 of 35 nodes were agents, only 13 edges, zero model/store nodes and generic entry hubs — even though the deployed prompt explicitly forbids that shape. Prose guidance mid-document gets skimmed, so this PR makes the requirement structural on both ends of the loop.

## Server: `auditPlanGraph`

New pure function in `@foglamp/contracts` (unit-tested), run by `createPlan` after schema validation. A failing map is bounced with the same `422 { details }` shape the agent already fixes-and-retries on:

- calls exist but **no `model` nodes** → rejected
- ≥8 nodes and **>80% agents** → rejected (the re-drawn-decisions shape)
- ≥6 nodes and **edges < nodes/2** → rejected (floating groups)
- most agent nodes with **no edges at all** → rejected
- ≥6 nodes and **no `entry`/`cron` node** → rejected

Thresholds are deliberately loose: a two-node map from a tiny repo passes even with no entry node or edges, as long as it names its model.

## Prompt: pre-upload checklist

Section 3 of `/setup/prompt` now ends with a 5-item audit checklist mirroring the server checks, closing with "trace one real request end to end (entry → agent → model/tool → store) and check the map shows that path." A checklist right before the upload step is much harder to skim past than descriptive prose — and the server now enforces it anyway.

The motivating plan fails three checks simultaneously; the well-wired same-size map in the tests passes clean.

## Verification

- `bun test packages/contracts/src/instrumentation.test.ts` — 36 pass (5 new)
- `bun check-types` — 11/11, `apps/web` tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V79vCcngLWPL1XE8bGAQ6V