### PR TITLE
Approve closes the tab, remove public share, full-height decision list

### DIFF
--- a/apps/web/src/app/setup/[planId]/setup-client.tsx
+++ b/apps/web/src/app/setup/[planId]/setup-client.tsx
@@ -28,35 +28,6 @@ import { trpc } from "@/utils/trpc";
 /** How often to re-read the plan while it can still change. */
 const POLL_MS = 2_000;
 
-/**
- * Where a plan's public-share credentials live in localStorage. Keeping the
- * editToken client-side (keyed by plan) is what makes "Share" idempotent: a
- * re-share updates the same /scan slug instead of minting a new URL.
- */
-const shareStorageKey = (planId: string) => `foglamp.setup.share.${planId}`;
-
-interface StoredShare {
-  slug: string;
-  editToken: string;
-}
-
-function readStoredShare(planId: string): StoredShare | null {
-  try {
-    const raw = localStorage.getItem(shareStorageKey(planId));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<StoredShare>;
-    if (
-      typeof parsed.slug !== "string" ||
-      typeof parsed.editToken !== "string"
-    ) {
-      return null;
-    }
-    return { slug: parsed.slug, editToken: parsed.editToken };
-  } catch {
-    return null;
-  }
-}
-
 export function SetupClient({ planId }: { planId: string }) {
   const qc = useQueryClient();
   const queryKey = trpc.instrumentationPlans.get.queryKey({ planId });
@@ -104,52 +75,24 @@ export function SetupClient({ planId }: { planId: string }) {
     });
   }, [data]);
 
-  // Browsers won't let a page close a tab it didn't open, so the next best
-  // thing to "approve closes the tab" is saying out loud that closing is safe:
-  // the agent is unblocked the moment the approval lands, not when this page
-  // is looked at.
+  // Approving is the end of the user's job here — the agent is unblocked the
+  // moment the approval lands, so the tab tries to close itself. Browsers only
+  // honor window.close() for tabs with no real history (which is exactly what
+  // the agent's `open <reviewUrl>` produces, on Chromium at least); when it's
+  // blocked the dialog says out loud that closing is safe.
   const [approvedOpen, setApprovedOpen] = useState(false);
 
   const approve = useMutation(
     trpc.instrumentationPlans.approve.mutationOptions({
       onSuccess: async () => {
         captureActivationEvent("instrumentation_plan_approved");
-        setApprovedOpen(true);
+        window.close();
+        // Only reached when the browser refused to close the tab. The delay
+        // keeps the dialog from flashing during an honored close.
+        window.setTimeout(() => setApprovedOpen(true), 400);
         // Refetch immediately: the agent resumes within a second or so, and the
         // page should be showing "applying" by the time the user looks up.
         await qc.invalidateQueries({ queryKey });
-      },
-      onError: (e) => toast.error(e.message),
-    })
-  );
-
-  // The opt-in public share of the instrumented map. Deliberately not part of
-  // the plan row: the credentials are the same anonymous-scan editToken the
-  // /scan lead magnet uses, held only in this browser.
-  const [share, setShare] = useState<StoredShare | null>(null);
-  useEffect(() => {
-    setShare(readStoredShare(planId));
-  }, [planId]);
-
-  const shareMap = useMutation(
-    trpc.instrumentationPlans.share.mutationOptions({
-      onSuccess: (res) => {
-        captureActivationEvent("instrumentation_map_shared", {
-          updated: res.updated,
-        });
-        const stored = { slug: res.slug, editToken: res.editToken };
-        setShare(stored);
-        try {
-          localStorage.setItem(shareStorageKey(planId), JSON.stringify(stored));
-        } catch {
-          // Storage disabled — the share still worked, a re-share just mints
-          // a fresh URL instead of updating this one.
-        }
-        const url = `${window.location.origin}/scan/${res.slug}`;
-        void navigator.clipboard
-          .writeText(url)
-          .then(() => toast.success("Public map link copied"))
-          .catch(() => toast.success("Public map published"));
       },
       onError: (e) => toast.error(e.message),
     })
@@ -204,9 +147,6 @@ export function SetupClient({ planId }: { planId: string }) {
         onApprove={(edits) => approve.mutate({ planId, edits })}
         onReject={() => reject.mutate({ planId })}
         approving={approve.isPending || reject.isPending}
-        shareSlug={share?.slug ?? null}
-        onShare={() => shareMap.mutate({ planId, editToken: share?.editToken })}
-        sharing={shareMap.isPending}
       />
       <Dialog open={approvedOpen} onOpenChange={setApprovedOpen}>
         <DialogContent className="sm:max-w-sm">
@@ -214,7 +154,7 @@ export function SetupClient({ planId }: { planId: string }) {
             <DialogTitle>Approved</DialogTitle>
             <DialogDescription>
               Your coding agent picked the plan up and is implementing the
-              instrumentation.
+              instrumentation. You can close this tab.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/apps/web/src/components/setup/setup-board.tsx
+++ b/apps/web/src/components/setup/setup-board.tsx
@@ -71,9 +71,6 @@ export function SetupBoard({
   onApprove,
   onReject,
   approving,
-  shareSlug,
-  onShare,
-  sharing,
 }: {
   plan: DetectedPlan;
   /** The decisions actually agreed to (detected + edits), once approved. */
@@ -88,10 +85,6 @@ export function SetupBoard({
   onApprove: (edits: PlanEdits | undefined) => void;
   onReject: () => void;
   approving: boolean;
-  /** The public /scan slug once this plan's map has been shared. */
-  shareSlug?: string | null;
-  onShare?: () => void;
-  sharing?: boolean;
 }) {
   const [focus, setFocusState] = useState<SetupFocus>(null);
   // Spotlighting re-renders the whole map, so hover commits are debounced:
@@ -196,7 +189,7 @@ export function SetupBoard({
       {/* The one column: what was found + approve, then why. The page never
           scrolls — the decisions card fills whatever height the summary
           leaves and scrolls inside itself. */}
-      <div className="absolute top-6 bottom-24 left-6 z-20 flex w-72 flex-col gap-4">
+      <div className="absolute top-6 bottom-6 left-6 z-20 flex w-72 flex-col gap-4">
         <SetupSummary
           plan={plan}
           status={status}
@@ -213,9 +206,6 @@ export function SetupBoard({
             verified={status === "verified"}
             spanCount={spanCount}
             secondsToFirstTrace={secondsToFirstTrace}
-            shareSlug={shareSlug}
-            onShare={onShare}
-            sharing={sharing}
           />
         ) : null}
         <DecisionList

--- a/apps/web/src/components/setup/verification-report.tsx
+++ b/apps/web/src/components/setup/verification-report.tsx
@@ -2,7 +2,6 @@
 
 import type { AppliedReport } from "@foglamp/contracts/instrumentation";
 import type { ScanData } from "@foglamp/contracts/scan";
-import { Button } from "@foglamp/ui/components/button";
 import { Card, CardContent } from "@foglamp/ui/components/card";
 import { cn } from "@foglamp/ui/lib/utils";
 import {
@@ -13,7 +12,6 @@ import {
   IconFileDiffFilled,
   IconMinus,
   IconPlusFilled,
-  IconWorldShare,
 } from "@tabler/icons-react";
 import { useMemo, useState } from "react";
 
@@ -87,9 +85,6 @@ export function VerificationReport({
   verified,
   spanCount,
   secondsToFirstTrace,
-  shareSlug,
-  onShare,
-  sharing,
 }: {
   /** The scan the plan was approved against — the "before" of the diff. */
   before: ScanData;
@@ -97,10 +92,6 @@ export function VerificationReport({
   verified: boolean;
   spanCount?: number | null;
   secondsToFirstTrace?: number | null;
-  /** Public /scan slug once shared; the footer flips from ask to link. */
-  shareSlug?: string | null;
-  onShare?: () => void;
-  sharing?: boolean;
 }) {
   const diff = useMemo(() => diffScans(report.scan, before), [report, before]);
   const instrumented = report.calls.filter((c) => c.instrumented).length;
@@ -232,47 +223,6 @@ export function VerificationReport({
           </Section>
         ) : null}
       </CardContent>
-
-      {onShare ? (
-        <div className="flex shrink-0 items-center justify-between gap-3 border-t px-5 py-3">
-          {shareSlug ? (
-            <>
-              <a
-                href={`/scan/${encodeURIComponent(shareSlug)}`}
-                target="_blank"
-                rel="noreferrer"
-                className="flex min-w-0 items-center gap-1.5 text-[11px] font-medium hover:underline"
-              >
-                <IconWorldShare className="size-3.5 flex-none text-muted-foreground" />
-                <span className="truncate">View your public map</span>
-              </a>
-              <button
-                type="button"
-                onClick={onShare}
-                disabled={sharing}
-                className="shrink-0 cursor-pointer text-[11px] font-medium text-muted-foreground/60 hover:text-foreground disabled:cursor-default"
-              >
-                {sharing ? "Updating…" : "Update"}
-              </button>
-            </>
-          ) : (
-            <>
-              <p className="text-[11px] leading-snug text-muted-foreground">
-                Share a public, read-only map — structure only, never code.
-              </p>
-              <Button
-                size="sm"
-                variant="secondary"
-                className="shrink-0"
-                onClick={onShare}
-                disabled={sharing}
-              >
-                {sharing ? "Sharing…" : "Share"}
-              </Button>
-            </>
-          )}
-        </div>
-      ) : null}
     </Card>
   );
 }

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -11,8 +11,7 @@ type ClientActivationEvent =
   // of the funnel is captured server-side (@foglamp/analytics), since it's
   // driven by the user's coding agent.
   | "instrumentation_plan_viewed"
-  | "instrumentation_plan_approved"
-  | "instrumentation_map_shared";
+  | "instrumentation_plan_approved";
 
 export function captureActivationEvent(
   event: ClientActivationEvent,

--- a/packages/api/src/routers/instrumentationPlans.ts
+++ b/packages/api/src/routers/instrumentationPlans.ts
@@ -10,7 +10,6 @@ import {
   rejectPlan,
   verifyFirstTrace,
 } from "../services/instrumentationPlans";
-import { claimScan, createOrUpdateScan } from "../services/scans";
 
 // The browser half of the onboarding approval loop. The agent half is a set of
 // API-key-authed REST routes in apps/server/src/instrumentation.ts — the two
@@ -95,60 +94,6 @@ export const instrumentationPlansRouter = router({
         });
       }
       return { status: res.row.status };
-    }),
-
-  /**
-   * The explicit, opt-in public share (Stage 3, part 2). Publishes the agent's
-   * after-scan — already a validated, sanitized `ScanData`, the exact contract
-   * the anonymous /scan lead magnet uses, so nothing beyond structured
-   * metadata can leave — as a public scan page. Re-sharing with the editToken
-   * from a previous share updates the same slug instead of minting a new URL.
-   */
-  share: protectedProcedure
-    .input(
-      z.object({
-        planId: z.string().min(1).max(64),
-        editToken: z.string().min(1).max(128).optional(),
-      })
-    )
-    .mutation(async ({ ctx, input }) => {
-      const plan = await getPlanForUser(
-        ctx.db,
-        ctx.session.user.id,
-        input.planId
-      );
-      if (!plan) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Plan not found" });
-      }
-      if (!plan.applied) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: "There's nothing to share until your agent applies the plan",
-        });
-      }
-      const outcome = await createOrUpdateScan(ctx.db, {
-        data: plan.applied.scan,
-        editToken: input.editToken,
-      });
-      if (!outcome.ok) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: `This map can't be shared: ${outcome.errors.join("; ")}`,
-        });
-      }
-      // Claim it for the sharer right away: a map published from a signed-in
-      // setup shouldn't self-destruct on the anonymous 90-day TTL. Best-effort
-      // — the share itself already succeeded.
-      await claimScan(ctx.db, {
-        slug: outcome.result.slug,
-        editToken: outcome.result.editToken,
-        userId: ctx.session.user.id,
-      });
-      return {
-        slug: outcome.result.slug,
-        editToken: outcome.result.editToken,
-        updated: outcome.result.updated,
-      };
     }),
 
   reject: protectedProcedure


### PR DESCRIPTION
Three changes to the setup review page after testing the full loop:

## Approve closes the tab
The user's job ends at the Approve click — the agent resumes off the long-poll, not off this page. On success the page now calls `window.close()`. The agent opens the review URL with `open`/`xdg-open`, producing a tab with no history, which is the case Chromium honors `window.close()` for. If the browser refuses (Firefox default), the existing "Approved" dialog appears after 400ms and now adds "You can close this tab."

## Public share removed
The Stage 3 opt-in share of the instrumented map is fully removed: the `instrumentationPlans.share` tRPC mutation, the verification-report footer (Share button / public link), the localStorage editToken persistence in the setup client, and the `instrumentation_map_shared` analytics event. The verification report card itself (coverage, map diff, files changed, warnings) is untouched. Nothing here touched the anonymous `/scan` pipeline — `createOrUpdateScan`/`claimScan` remain as they were for the lead magnet.

## Decision list uses the full viewport height
The left column was pinned `bottom-24`, leaving a 96px dead band under the decisions card. It's now `bottom-6`, matching the top/left margins, and the card's internal scroll picks up the extra height.

## Verification
- `bun check-types` — 11/11
- `apps/web` `tsc --noEmit` — clean
- No remaining `share` references under `components/setup`, `app/setup`, or the plans router

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V79vCcngLWPL1XE8bGAQ6V