### PR TITLE
fix(setup): close the review flow's dead ends

### DIFF
--- a/apps/web/src/app/setup/[planId]/setup-client.tsx
+++ b/apps/web/src/app/setup/[planId]/setup-client.tsx
@@ -28,6 +28,20 @@ import { trpc } from "@/utils/trpc";
 /** How often to re-read the plan while it can still change. */
 const POLL_MS = 2_000;
 
+/**
+ * Polling `applied` runs the first-trace probe (a ClickHouse query) on every
+ * tick, and "waiting for the user to trigger a flow" can last a long while —
+ * so that one state backs off instead of hammering: snappy for the first
+ * minute (the demo case: agent applies, user triggers immediately), then
+ * progressively lazier.
+ */
+function appliedPollMs(appliedAt: string | null | undefined): number {
+  const since = Date.now() - (appliedAt ? Date.parse(appliedAt) : Date.now());
+  if (since < 60_000) return POLL_MS;
+  if (since < 300_000) return 5_000;
+  return 10_000;
+}
+
 export function SetupClient({ planId }: { planId: string }) {
   const qc = useQueryClient();
   const queryKey = trpc.instrumentationPlans.get.queryKey({ planId });
@@ -42,6 +56,9 @@ export function SetupClient({ planId }: { planId: string }) {
         refetchInterval: (query) => {
           const status = query.state.data?.status;
           if (status && !isPlanPending(status)) return false;
+          if (status === "applied") {
+            return appliedPollMs(query.state.data?.appliedAt);
+          }
           return POLL_MS;
         },
         retry: false,
@@ -141,6 +158,8 @@ export function SetupClient({ planId }: { planId: string }) {
         applied={data.applied}
         status={data.status}
         firstTraceId={data.firstTraceId}
+        approvedAt={data.approvedAt}
+        agentResumedAt={data.agentResumedAt}
         spanCount={data.spanCount}
         secondsToFirstTrace={data.secondsToFirstTrace}
         failureStage={data.failureStage}

--- a/apps/web/src/components/setup/setup-board.tsx
+++ b/apps/web/src/components/setup/setup-board.tsx
@@ -65,6 +65,8 @@ export function SetupBoard({
   applied,
   status,
   firstTraceId,
+  approvedAt,
+  agentResumedAt,
   spanCount,
   secondsToFirstTrace,
   failureStage,
@@ -79,6 +81,9 @@ export function SetupBoard({
   applied?: AppliedReport | null;
   status: PlanStatus;
   firstTraceId?: string | null;
+  /** ISO timestamps — tRPC serializes dates to strings on this app. */
+  approvedAt?: string | null;
+  agentResumedAt?: string | null;
   spanCount?: number | null;
   secondsToFirstTrace?: number | null;
   failureStage?: string | null;
@@ -169,6 +174,16 @@ export function SetupBoard({
     return { agents, workflows, sessions, customer: edits.customer };
   }, [edits]);
 
+  // The one edit that can make approval fail server-side: customer attribution
+  // switched on with no id source. Catch it here and disable Approve — the
+  // decision row already explains what's missing — instead of letting the
+  // click round-trip into a schema-speak error toast.
+  const customerOn =
+    edits.customer?.recommended ?? plan.decisions.customer.recommended;
+  const customerIdSource =
+    edits.customer?.idSource ?? plan.decisions.customer.idSource;
+  const approveBlocked = customerOn && !customerIdSource;
+
   // Post-approval the source of truth flips: the list shows what was agreed
   // to (detected + edits), not the raw detection.
   const decisions = approved ?? plan.decisions;
@@ -194,7 +209,10 @@ export function SetupBoard({
           plan={plan}
           status={status}
           firstTraceId={firstTraceId}
+          approvedAt={approvedAt}
+          agentResumedAt={agentResumedAt}
           failureStage={failureStage}
+          approveBlocked={approveBlocked}
           onApprove={() => onApprove(buildEdits())}
           onReject={onReject}
           approving={approving}

--- a/apps/web/src/components/setup/setup-summary.tsx
+++ b/apps/web/src/components/setup/setup-summary.tsx
@@ -11,6 +11,7 @@ import { cn } from "@foglamp/ui/lib/utils";
 import { IconCheck, IconExclamationCircle } from "@tabler/icons-react";
 import type { Route } from "next";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
 // The one card that runs the whole show: what Foglamp found, the approve /
 // reject actions, and — once the user has clicked — a compact live status line
@@ -60,6 +61,13 @@ const STATUS_LINE: Record<
   },
 };
 
+// The two "your agent might be gone" thresholds. A live wait loop picks an
+// approval up in ~1 second, so a couple of minutes in `approved` means the
+// agent almost certainly stopped waiting (its loop gives up after ~30 min).
+// Applying is real work, so it gets far more slack before we raise an eyebrow.
+const AGENT_GONE_MS = 2 * 60_000;
+const APPLY_SLOW_MS = 10 * 60_000;
+
 const TONE_TEXT: Record<Tone, string> = {
   working: "text-muted-foreground",
   done: "text-emerald-600 dark:text-emerald-400",
@@ -82,7 +90,10 @@ export function SetupSummary({
   plan,
   status,
   firstTraceId,
+  approvedAt,
+  agentResumedAt,
   failureStage,
+  approveBlocked,
   onApprove,
   onReject,
   approving,
@@ -90,11 +101,38 @@ export function SetupSummary({
   plan: DetectedPlan;
   status: PlanStatus;
   firstTraceId?: string | null;
+  /** ISO timestamps — tRPC serializes dates to strings on this app. */
+  approvedAt?: string | null;
+  agentResumedAt?: string | null;
   failureStage?: string | null;
+  /** A decision is incomplete (customer attribution without an id source). */
+  approveBlocked?: boolean;
   onApprove: () => void;
   onReject: () => void;
   approving: boolean;
 }) {
+  // Rejecting is terminal — the agent exits and the only way back is pasting
+  // the whole prompt again — so one stray click next to Approve must not end
+  // the session. First click arms, second click fires, a pause disarms.
+  const [confirmReject, setConfirmReject] = useState(false);
+  useEffect(() => {
+    if (!confirmReject) return;
+    const t = window.setTimeout(() => setConfirmReject(false), 5_000);
+    return () => window.clearTimeout(t);
+  }, [confirmReject]);
+
+  // Recomputed on every poll-driven render (the page refetches every couple
+  // of seconds while the plan can still move), so these flip on their own.
+  const now = Date.now();
+  const agentGone =
+    status === "approved" &&
+    approvedAt != null &&
+    now - Date.parse(approvedAt) > AGENT_GONE_MS;
+  const applyStartedAt = agentResumedAt ?? approvedAt;
+  const applySlow =
+    status === "applying" &&
+    applyStartedAt != null &&
+    now - Date.parse(applyStartedAt) > APPLY_SLOW_MS;
   const parts: string[] = [];
   const { agents, workflows, sessions } = plan.decisions;
   if (agents.length) parts.push(plural(agents.length, "agent"));
@@ -112,25 +150,41 @@ export function SetupSummary({
           </span>
         </h1>
         {status === "awaiting_approval" ? (
-          <div className="mt-4 flex items-center justify-end gap-2">
-            <Button
-              size="sm"
-              variant="secondary"
-              className="flex-1"
-              onClick={onReject}
-              disabled={approving}
-            >
-              Reject
-            </Button>
-            <Button
-              size="sm"
-              className="flex-1"
-              onClick={onApprove}
-              disabled={approving}
-            >
-              {approving ? "Approving…" : "Approve"}
-            </Button>
-          </div>
+          <>
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <Button
+                size="sm"
+                variant={confirmReject ? "destructive" : "secondary"}
+                className="flex-1"
+                onClick={() => {
+                  if (confirmReject) onReject();
+                  else setConfirmReject(true);
+                }}
+                disabled={approving}
+              >
+                {confirmReject ? "Really reject?" : "Reject"}
+              </Button>
+              <Button
+                size="sm"
+                className="flex-1"
+                onClick={onApprove}
+                disabled={approving || approveBlocked}
+              >
+                {approving ? "Approving…" : "Approve"}
+              </Button>
+            </div>
+            {approveBlocked ? (
+              <p className="mt-2 text-[11px] leading-relaxed text-amber-600 dark:text-amber-400">
+                Add a customer id source below — or turn attribution off — to
+                approve.
+              </p>
+            ) : null}
+            {confirmReject ? (
+              <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+                Rejecting stops your agent; nothing in your repo changes.
+              </p>
+            ) : null}
+          </>
         ) : (
           <div className={cn("mt-4")}>
             <div
@@ -149,6 +203,19 @@ export function SetupSummary({
                 </p>
               </div>
             </div>
+            {agentGone ? (
+              <p className="mt-2 text-[11px] leading-relaxed text-amber-600 dark:text-amber-400">
+                Still waiting? Your agent probably stopped listening. Send it
+                any message — &ldquo;continue&rdquo; works — and it will pick
+                this plan up.
+              </p>
+            ) : null}
+            {applySlow ? (
+              <p className="mt-2 text-[11px] leading-relaxed text-amber-600 dark:text-amber-400">
+                This is taking a while. Check your agent&rsquo;s output — it
+                may be stuck or waiting on you.
+              </p>
+            ) : null}
             {status === "verified" && firstTraceId ? (
               <Button
                 size="sm"

--- a/apps/web/src/lib/setup-prompt.ts
+++ b/apps/web/src/lib/setup-prompt.ts
@@ -206,8 +206,11 @@ nothing and returns within a second of the user clicking. What it prints:
 - \`rejected\` — stop. Change nothing. Tell the user their repo is untouched.
 - \`expired\` — the plan timed out. Start again at step 1.
 - nothing at all — the 7-minute bound was hit. Run the exact same command again.
-  After about 30 minutes with no answer, stop and tell the user to approve the
-  link whenever they're ready and you'll continue then.
+  After about 30 minutes with no answer, stop and tell the user exactly this:
+  "Approve the review link whenever you're ready, then send me any message
+  (just 'continue' works) and I'll pick the plan up." When they come back, run
+  the same wait command again — it returns instantly once the plan is approved,
+  and everything continues from step 5 as if you'd never stopped.
 
 ## 5. Apply the approved plan
 Fetch ${AGENT_DOCS_URL} and follow it.

--- a/packages/api/src/routers/instrumentationPlans.ts
+++ b/packages/api/src/routers/instrumentationPlans.ts
@@ -54,6 +54,10 @@ export const instrumentationPlansRouter = router({
         expiresAt: plan.expiresAt,
         createdAt: plan.createdAt,
         approvedAt: plan.approvedAt,
+        // Null while `approved` means no agent has picked the plan up — the
+        // page uses that (plus elapsed time) to tell the user their agent
+        // probably stopped waiting.
+        agentResumedAt: plan.agentResumedAt,
         appliedAt: plan.appliedAt,
         firstTraceId: verification.firstTraceId,
         verifiedAt: verification.verifiedAt,

--- a/packages/api/src/services/instrumentationPlans.ts
+++ b/packages/api/src/services/instrumentationPlans.ts
@@ -39,17 +39,19 @@ import { requireProjectAccess } from "./access";
 /** Plans self-destruct if nobody acts on them. */
 const PLAN_TTL_HOURS = env.SETUP_PLAN_TTL_HOURS;
 
-/** Statuses the expiry sweep is allowed to reap (see canTransition). */
-const EXPIRABLE: PlanStatus[] = ["awaiting_approval", "approved"];
+/**
+ * Statuses the expiry sweep is allowed to reap (see canTransition). `applying`
+ * is here for the agent that died mid-apply — without it that plan would spin
+ * on the review page forever. `applied` is not: the code changes are real, the
+ * plan is just waiting on a trace, and that wait is legitimately unbounded.
+ */
+const EXPIRABLE: PlanStatus[] = ["awaiting_approval", "approved", "applying"];
 
 /**
  * How a plan reads right now. A plan past its deadline is expired the moment
  * anyone looks at it, not whenever the hourly sweep gets to it — otherwise an
  * agent could wait on a dead plan, and the review page would keep saying
  * "waiting for your coding agent" for up to an hour after it died.
- *
- * Only the reapable statuses are projected: once an agent is mid-apply the
- * deadline stops mattering, and the sweep won't touch it either.
  */
 export function effectiveStatus(plan: {
   status: PlanStatus;

--- a/packages/contracts/src/instrumentation.test.ts
+++ b/packages/contracts/src/instrumentation.test.ts
@@ -68,7 +68,7 @@ describe("canTransition", () => {
     // An approved-but-never-collected plan still ages out.
     expect(canTransition("approved", "expired")).toBe(true);
     // ...but once the agent is mid-apply, expiry must not yank it away.
-    expect(canTransition("applying", "expired")).toBe(false);
+    expect(canTransition("applying", "expired")).toBe(true);
     expect(canTransition("applied", "expired")).toBe(false);
   });
 

--- a/packages/contracts/src/instrumentation.ts
+++ b/packages/contracts/src/instrumentation.ts
@@ -74,7 +74,11 @@ export const TERMINAL_STATUSES = ["verified", "rejected", "expired", "failed"] a
 const TRANSITIONS: Record<PlanStatus, readonly PlanStatus[]> = {
   awaiting_approval: ["approved", "rejected", "expired"],
   approved: ["applying", "expired", "failed"],
-  applying: ["applied", "failed"],
+  // `expired` here covers the agent that died mid-apply (crashed, laptop
+  // closed): without it the plan would sit in `applying` forever and the
+  // review page would spin until the end of time. The TTL is generous (24h),
+  // so a healthy apply — minutes — never gets close.
+  applying: ["applied", "expired", "failed"],
   applied: ["verified", "failed"],
   // Terminal — absorbing states.
   verified: [],


### PR DESCRIPTION
Fixes the five dead ends / rough edges from the onboarding-flow review:

1. **Approve after the agent gave up** — the review page detects a plan sitting in `approved` with no agent pickup for 2+ minutes and tells the user to poke their agent ("send it any message — 'continue' works"). The `/setup/prompt` wait-loop copy now gives the agent the matching resume instructions when it stops waiting.
2. **Agent dies mid-apply** — `applying → expired` is now a legal transition, the hourly sweep and `effectiveStatus` projection reap it at the TTL, and the page shows a "check your agent's output" nudge after 10 minutes of applying.
3. **Customer attribution without an id source** — Approve is disabled with an inline hint instead of round-tripping into `These edits can't be applied: (root): idSource is required…`.
4. **One-click terminal Reject** — two-step confirm: first click arms (destructive "Really reject?"), second fires, auto-disarms after 5s.
5. **ClickHouse probe every 2s while `applied`** — the page poll backs off 2s → 5s (after 1 min) → 10s (after 5 min).

Also exposes `agentResumedAt` in `instrumentationPlans.get` for the nudges.

Verified: `bun test packages/contracts/src/instrumentation.test.ts` (36 pass, matrix updated for `applying → expired`), `bun check-types`, web `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V79vCcngLWPL1XE8bGAQ6V