### PR TITLE
fix(analytics): make the onboarding funnel's drop-off signals real

### DIFF
--- a/apps/web/src/app/setup/[planId]/setup-client.tsx
+++ b/apps/web/src/app/setup/[planId]/setup-client.tsx
@@ -102,7 +102,7 @@ export function SetupClient({ planId }: { planId: string }) {
   const approve = useMutation(
     trpc.instrumentationPlans.approve.mutationOptions({
       onSuccess: async () => {
-        captureActivationEvent("instrumentation_plan_approved");
+        captureActivationEvent("instrumentation_plan_approve_clicked");
         window.close();
         // Only reached when the browser refused to close the tab. The delay
         // keeps the dialog from flashing during an honored close.

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -9,9 +9,12 @@ type ClientActivationEvent =
   | "trace_viewed"
   // The two moments of the approval loop that happen in the browser. The rest
   // of the funnel is captured server-side (@foglamp/analytics), since it's
-  // driven by the user's coding agent.
+  // driven by the user's coding agent. The click event is deliberately NOT
+  // named `instrumentation_plan_approved`: that name belongs to the server
+  // event attributed to the org owner, and when a non-owner teammate clicks,
+  // a same-named browser event on a different person would split the funnel.
   | "instrumentation_plan_viewed"
-  | "instrumentation_plan_approved";
+  | "instrumentation_plan_approve_clicked";
 
 export function captureActivationEvent(
   event: ClientActivationEvent,

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -18,6 +18,7 @@ export type ActivationEvent =
   | "instrumentation_changes_applied"
   | "instrumentation_waiting_for_trace"
   | "instrumentation_verified"
+  | "instrumentation_plan_rejected"
   | "instrumentation_plan_expired"
   | "instrumentation_plan_failed";
 

--- a/packages/api/src/services/instrumentationPlans.ts
+++ b/packages/api/src/services/instrumentationPlans.ts
@@ -278,12 +278,23 @@ export async function rejectPlan(
 ): Promise<TransitionOutcome> {
   const plan = await getPlanForUser(db, userId, planId);
   if (!plan) return { ok: false, reason: "not_found" };
-  return transition(db, {
+  const res = await transition(db, {
     planId,
     from: ["awaiting_approval"],
     to: "rejected",
     set: { rejectedAt: new Date() },
   });
+  if (res.ok && res.changed) {
+    // A rejection is the funnel's most interesting drop-off — without this
+    // event a user who said "no" is indistinguishable from one who never
+    // opened the tab.
+    const owner = await ownerOfOrg(db, plan.orgId);
+    void capture("instrumentation_plan_rejected", owner, {
+      project_id: plan.projectId,
+      seconds_to_rejection: secondsBetween(plan.createdAt, new Date()),
+    });
+  }
+  return res;
 }
 
 /**
@@ -478,10 +489,26 @@ export async function expireStalePlans(db: Db): Promise<number> {
         lt(instrumentationPlan.expiresAt, new Date()),
       ),
     )
-    .returning({ id: instrumentationPlan.id, projectId: instrumentationPlan.projectId });
+    .returning({
+      id: instrumentationPlan.id,
+      projectId: instrumentationPlan.projectId,
+      orgId: instrumentationPlan.orgId,
+    });
 
+  // Attribute each expiry to its org owner like every other funnel event —
+  // `capture` drops events with no distinctId, so passing null here would
+  // (and historically did) silently erase expiries from the funnel. One
+  // owner lookup per org, not per row.
+  const owners = new Map<string, string | null>();
   for (const row of expired) {
-    void capture("instrumentation_plan_expired", null, { project_id: row.projectId });
+    let owner = owners.get(row.orgId);
+    if (owner === undefined) {
+      owner = await ownerOfOrg(db, row.orgId);
+      owners.set(row.orgId, owner);
+    }
+    void capture("instrumentation_plan_expired", owner, {
+      project_id: row.projectId,
+    });
   }
   return expired.length;
 }


### PR DESCRIPTION
Three fixes from the PostHog integration audit of the onboarding flow:

1. **`instrumentation_plan_expired` never fired.** `expireStalePlans` passed `distinctId: null` and `capture()` drops null-identity events — every expiry was silently erased from the funnel. The sweep now resolves the org owner per expired plan (memoized per org) and attributes the event like every other step.
2. **Rejections were untracked.** `rejectPlan` now emits `instrumentation_plan_rejected` (org-owner identity, `project_id`, `seconds_to_rejection`) on the winning transition only — the funnel can finally tell "said no" apart from "abandoned the tab".
3. **Client/server approve event collision.** The browser click event is renamed `instrumentation_plan_approve_clicked`; `instrumentation_plan_approved` is now exclusively the server event on the org-owner identity, so a non-owner teammate clicking no longer splits the funnel across two persons.

No schema or contract changes. Verified: `bun check-types`, web `tsc --noEmit`.

**PostHog side (manual):** update the funnel insight to the server-event chain `instrumentation_plan_created → _approved → _agent_resumed → _changes_applied → _verified`, remove any step on the deleted `instrumentation_map_shared`, and use `_rejected` / `_expired` / `_failed` as drop-off breakdowns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V79vCcngLWPL1XE8bGAQ6V